### PR TITLE
feat(api): bootstrap apps/core/api with Hono + minimal stock CRUD

### DIFF
--- a/apps/core/api/.env.example
+++ b/apps/core/api/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+PORT=3000

--- a/apps/core/api/package.json
+++ b/apps/core/api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@prep-hamster/api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@prep-hamster/db": "workspace:*",
+    "@prep-hamster/schema": "workspace:*",
+    "@hono/zod-validator": "^0.4.0",
+    "drizzle-orm": "^0.36.0",
+    "hono": "^4.6.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/apps/core/api/src/__tests__/smoke.test.ts
+++ b/apps/core/api/src/__tests__/smoke.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test"
+import type { Db } from "@prep-hamster/db"
+import { createApp } from "../app"
+
+const mockDb = {} as Db
+
+test("GET /health returns ok", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request("/health")
+  expect(res.status).toBe(200)
+  expect(await res.json()).toEqual({ ok: true })
+})
+
+test("GET /v1/stocks without x-user-id returns 401", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request(
+    "/v1/stocks?groupId=00000000-0000-0000-0000-000000000000",
+  )
+  expect(res.status).toBe(401)
+})
+
+test("POST /v1/stocks without x-user-id returns 401", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request("/v1/stocks", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  })
+  expect(res.status).toBe(401)
+})
+
+test("GET /v1/stocks with invalid groupId returns 400", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request("/v1/stocks?groupId=not-a-uuid", {
+    headers: { "x-user-id": "00000000-0000-0000-0000-000000000000" },
+  })
+  expect(res.status).toBe(400)
+})

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono"
+import type { Db } from "@prep-hamster/db"
+import { stocksRouter } from "./routes/stocks"
+
+export type AppEnv = {
+  Variables: {
+    db: Db
+    userId: string
+  }
+}
+
+export function createApp(opts: { db: Db }) {
+  return new Hono<AppEnv>()
+    .use("*", async (c, next) => {
+      c.set("db", opts.db)
+      await next()
+    })
+    .get("/health", (c) => c.json({ ok: true as const }))
+    .use("/v1/*", async (c, next) => {
+      const userId = c.req.header("x-user-id")
+      if (!userId) {
+        return c.json({ error: "x-user-id header required" }, 401)
+      }
+      c.set("userId", userId)
+      await next()
+    })
+    .route("/v1/stocks", stocksRouter)
+}
+
+export type AppType = ReturnType<typeof createApp>

--- a/apps/core/api/src/index.ts
+++ b/apps/core/api/src/index.ts
@@ -1,8 +1,16 @@
-import { Hono } from "hono"
+import { createDb } from "@prep-hamster/db"
+import { createApp } from "./app"
 
-const app = new Hono()
+const DEFAULT_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
-app.get("/health", (c) => c.json({ ok: true }))
+const db = createDb(process.env.DATABASE_URL ?? DEFAULT_DB_URL)
+const app = createApp({ db })
 
-export type AppType = typeof app
-export default app
+const port = Number(process.env.PORT ?? 3000)
+
+console.log(`[api] listening on http://localhost:${port}`)
+
+export default {
+  port,
+  fetch: app.fetch,
+}

--- a/apps/core/api/src/index.ts
+++ b/apps/core/api/src/index.ts
@@ -1,0 +1,8 @@
+import { Hono } from "hono"
+
+const app = new Hono()
+
+app.get("/health", (c) => c.json({ ok: true }))
+
+export type AppType = typeof app
+export default app

--- a/apps/core/api/src/routes/stocks.ts
+++ b/apps/core/api/src/routes/stocks.ts
@@ -1,0 +1,53 @@
+import { Hono } from "hono"
+import { zValidator } from "@hono/zod-validator"
+import { and, eq, isNull } from "drizzle-orm"
+import { z } from "zod"
+import { stocks } from "@prep-hamster/db"
+import { StockSchema } from "@prep-hamster/schema"
+import type { AppEnv } from "../app"
+
+const ListQuerySchema = z.object({
+  groupId: z.string().uuid(),
+})
+
+const CreateStockBodySchema = StockSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  deletedAt: true,
+})
+
+export const stocksRouter = new Hono<AppEnv>()
+  .get("/", zValidator("query", ListQuerySchema), async (c) => {
+    const { groupId } = c.req.valid("query")
+    const db = c.get("db")
+
+    const rows = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.groupId, groupId), isNull(stocks.deletedAt)))
+
+    return c.json({ stocks: rows })
+  })
+  .post("/", zValidator("json", CreateStockBodySchema), async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+
+    const [created] = await db
+      .insert(stocks)
+      .values({
+        id: crypto.randomUUID(),
+        groupId: body.groupId,
+        itemId: body.itemId,
+        locationId: body.locationId,
+        quantity: body.quantity,
+        unit: body.unit,
+        useByDate: body.useByDate,
+        bestBeforeDate: body.bestBeforeDate,
+        openedAt: body.openedAt,
+        note: body.note,
+      })
+      .returning()
+
+    return c.json({ stock: created }, 201)
+  })

--- a/apps/core/api/tsconfig.json
+++ b/apps/core/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "apps/core/api": {
+      "name": "@prep-hamster/api",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hono/zod-validator": "^0.4.0",
+        "@prep-hamster/db": "workspace:*",
+        "@prep-hamster/schema": "workspace:*",
+        "drizzle-orm": "^0.36.0",
+        "hono": "^4.6.0",
+        "zod": "^3.24.0",
+      },
+    },
     "packages/db": {
       "name": "@prep-hamster/db",
       "version": "0.0.0",
@@ -82,7 +94,11 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
+    "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
+
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@prep-hamster/api": ["@prep-hamster/api@workspace:apps/core/api"],
 
     "@prep-hamster/db": ["@prep-hamster/db@workspace:packages/db"],
 
@@ -121,6 +137,8 @@
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "https-proxy-agent": ["https-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g=="],
 


### PR DESCRIPTION
Closes #4

## Summary
`apps/core/api` を Hono + Bun で立ち上げ、`@prep-hamster/db` 経由で在庫の最小 CRUD を提供する。

## Plan（実装順）
- [x] Hono アプリのスタブ（`/health` のみ）
- [ ] `createDb()` で Postgres 接続（`DATABASE_URL` env から取得）
- [ ] `GET /v1/stocks?groupId=...` 実装
- [ ] `POST /v1/stocks` 実装（`@hono/zod-validator` + StockSchema 派生）
- [ ] 仮認証ミドルウェア（`x-user-id` ヘッダで identify）
- [ ] スモークテスト（`bun:test`）
- [ ] README / `tech-stack.md` 更新（必要なら）

## Test plan
- [ ] `bun run --filter '*' typecheck` が通る
- [ ] `bunx supabase start` 後、`POST /v1/stocks` → `GET /v1/stocks` の往復が成功
- [ ] `bun test apps/core/api` が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)