### PR TITLE
feat(api-client): add packages/api-client with hc<AppType>

### DIFF
--- a/apps/core/api/package.json
+++ b/apps/core/api/package.json
@@ -3,6 +3,21 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "./src/app.ts",
+  "module": "./src/app.ts",
+  "types": "./src/app.ts",
+  "exports": {
+    ".": {
+      "types": "./src/app.ts",
+      "import": "./src/app.ts",
+      "default": "./src/app.ts"
+    },
+    "./server": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,17 @@
         "zod": "^3.24.0",
       },
     },
+    "packages/api-client": {
+      "name": "@prep-hamster/api-client",
+      "version": "0.0.0",
+      "dependencies": {
+        "@prep-hamster/api": "workspace:*",
+        "hono": "^4.6.0",
+      },
+      "devDependencies": {
+        "@prep-hamster/db": "workspace:*",
+      },
+    },
     "packages/db": {
       "name": "@prep-hamster/db",
       "version": "0.0.0",
@@ -99,6 +110,8 @@
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@prep-hamster/api": ["@prep-hamster/api@workspace:apps/core/api"],
+
+    "@prep-hamster/api-client": ["@prep-hamster/api-client@workspace:packages/api-client"],
 
     "@prep-hamster/db": ["@prep-hamster/db@workspace:packages/db"],
 

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep-hamster/api-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@prep-hamster/api": "workspace:*",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@prep-hamster/db": "workspace:*"
+  }
+}

--- a/packages/api-client/src/__tests__/smoke.test.ts
+++ b/packages/api-client/src/__tests__/smoke.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "bun:test"
+import { createApp } from "@prep-hamster/api"
+import type { Db } from "@prep-hamster/db"
+import { createApiClient, type ClientFetch } from "../index"
+
+const mockDb = {} as Db
+
+test("client integrates with createApp via shared fetch", async () => {
+  const app = createApp({ db: mockDb })
+  const client = createApiClient({
+    baseUrl: "http://localhost",
+    userId: "00000000-0000-0000-0000-000000000000",
+    fetch: app.request,
+  })
+
+  const res = await client.health.$get()
+  expect(res.status).toBe(200)
+  const data = await res.json()
+  expect(data).toEqual({ ok: true })
+})
+
+test("client propagates x-user-id header to fetch", async () => {
+  let receivedHeaders: Headers | undefined
+  const mockFetch: ClientFetch = async (input, init) => {
+    if (input instanceof Request) {
+      receivedHeaders = input.headers
+    } else {
+      receivedHeaders = new Headers(init?.headers)
+    }
+    return new Response('{"ok":true}', {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  const client = createApiClient({
+    baseUrl: "http://localhost",
+    userId: "user-abc",
+    fetch: mockFetch,
+  })
+
+  await client.health.$get()
+
+  expect(receivedHeaders?.get("x-user-id")).toBe("user-abc")
+})

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,24 @@
+import { hc } from "hono/client"
+import type { AppType } from "@prep-hamster/api"
+
+export type ClientFetch = (
+  input: Request | string | URL,
+  init?: RequestInit,
+) => Response | Promise<Response>
+
+export type ApiClientOptions = {
+  baseUrl: string
+  userId: string
+  fetch?: ClientFetch
+}
+
+export type ApiClient = ReturnType<typeof createApiClient>
+
+export function createApiClient(opts: ApiClientOptions) {
+  return hc<AppType>(opts.baseUrl, {
+    headers: {
+      "x-user-id": opts.userId,
+    },
+    ...(opts.fetch ? { fetch: opts.fetch } : {}),
+  })
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #6

## Summary
`@prep-hamster/api-client` を新規作成。Hono の `hc<AppType>` に `x-user-id` の仮認証ヘッダを pre-baked して、CLI / web / mobile から共通で使える型付きクライアントを提供する。

`@prep-hamster/api` の package.json に `main` / `exports` を追加し、ワークスペース内から `AppType` / `createApp` を import できるようにした。

## Changes

### `packages/api-client`
- `createApiClient({ baseUrl, userId, fetch? })` を export
- `ClientFetch` 型: DOM fetch と Hono の `app.request` の両方と互換になるよう、入力を `Request | string | URL` に緩和
- スモークテスト: `hc` + `app.request` を直結して `client.health.$get()` を呼び、x-user-id ヘッダがリクエストに乗るかを mock fetch で検証

### `apps/core/api/package.json`
- `main` / `module` / `types` / `exports.` を `./src/app.ts`（factory + AppType）に
- `exports['./server']` を `./src/index.ts`（Bun ランタイム入口）に

## Test plan
- [x] `bun run --filter '*' typecheck` が通る
- [x] `bun test packages/api-client` が 2/2 pass
- [x] `client.health.$get()` の戻り型が `Response` で、`.json()` の型が `{ ok: true }` 推論される

🤖 Generated with [Claude Code](https://claude.com/claude-code)