### PR TITLE
ci: add GitHub Actions workflow (typecheck + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run --filter '*' typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun test


### PR DESCRIPTION
Closes #10

## Summary
Phase 1-1: 基礎の CI を `.github/workflows/ci.yml` で導入。`pull_request` と `push to main` で **typecheck** と **test** を並列実行する。

## Changes
- `.github/workflows/ci.yml`
  - Bun セットアップ: `oven-sh/setup-bun@v2`（latest）
  - `bun install --frozen-lockfile` で `bun.lock` 整合性をゲート
  - typecheck job: `bun run --filter '*' typecheck`
  - test job: `bun test`
  - concurrency: 同一 ref の旧ジョブを `cancel-in-progress`

## Test plan
- [x] ローカル `bun run --filter '*' typecheck` が 6/6 workspace で通る
- [x] ローカル `bun test` が 18/18 pass
- [ ] この PR で CI が緑になる（self-test）

🤖 Generated with [Claude Code](https://claude.com/claude-code)