### PR TITLE
chore: add issue templates (bug + feature)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: 不具合を報告する
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が起きているか、1〜2 行で。
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 最小の再現手順を箇条書きで。
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待動作
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: エラーメッセージ・スタックトレース・スクリーンショットがあれば貼る。
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      description: OS / ブラウザ / Bun バージョン / commit SHA など、関連するもの。
+      placeholder: |
+        - OS:
+        - Bun:
+        - commit:
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 補足
+      description: 関連 Issue / 推定原因 / 回避策などがあれば。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: 機能追加や改善を提案する
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何をしたいか、1〜2 行で。
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why（動機・課題）
+      description: なぜ必要か。背景・困っていること・ユーザー影響。
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What（提案する変更）
+      description: どこで何をするか。実装イメージや UI/CLI の動作例があれば。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 検討した他の選択肢と、それを採用しない理由があれば。
+    validations:
+      required: false
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: 関連するが本 Issue では扱わない範囲。後続 Issue があればリンク。
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 関連 Issue / 参考リンク
+    validations:
+      required: false


### PR DESCRIPTION
## 概要 / Why
Issue 起票時に最低限の情報（再現手順 / 期待値 / 環境 など）が揃うよう、テンプレートで構造を統一する。bug / feature を分けて選びやすくする。

## 変更内容 / What
- `.github/ISSUE_TEMPLATE/bug_report.yml` を追加
  - 概要 / 再現手順 / 期待動作 / 実際の動作 / 環境 / 補足
  - title prefix `bug: `、label `bug` を自動付与
- `.github/ISSUE_TEMPLATE/feature_request.yml` を追加
  - 概要 / Why / What / 代替案 / Out of scope / 関連リンク
  - title prefix `feat: `、label `enhancement` を自動付与
- `.github/ISSUE_TEMPLATE/config.yml` を追加
  - `blank_issues_enabled: true`（学習用リポジトリのため、雑メモ的な Issue も許可）

## スコープ外 / Out of scope
- Discussion テンプレート
- Question 系テンプレート（blank issue で代用）
- ラベル整備（別 Issue で対応する場合あり）

## 検証 / Test plan
- [x] `bun run --filter '*' typecheck`
- [x] `bun test`
- [ ] PR マージ後、Issue 作成画面に bug / feature の選択肢が出ることを確認

## 関連 Issue / Links
- Closes #14