### PR TITLE
chore: add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+* text=auto eol=lf
+
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.pdf  binary
+*.zip  binary
+*.gz   binary
+*.woff  binary
+*.woff2 binary
+
+bun.lock          linguist-generated=true
+package-lock.json linguist-generated=true
+pnpm-lock.yaml    linguist-generated=true
+yarn.lock         linguist-generated=true
+
+packages/db/drizzle/** linguist-generated=true


### PR DESCRIPTION
## 概要 / Why
エディタ間でインデント / 改行 / EOF / 末尾空白の扱いがブレないようにする。Git の差分が無関係な改行差で汚れないよう、テキスト/バイナリの扱いも明示する。

## 変更内容 / What
- `.editorconfig`
  - 共通: `charset = utf-8`, `end_of_line = lf`, `insert_final_newline = true`, `trim_trailing_whitespace = true`
  - 共通: `indent_style = space`, `indent_size = 2`
  - `Makefile`: `indent_style = tab`
  - `*.md`: 末尾空白で改行（hard break）を扱うため `trim_trailing_whitespace = false`
- `.gitattributes`
  - `* text=auto eol=lf` で全テキストを LF に統一
  - 画像/フォント/PDF/zip 等を `binary`
  - lockfile (`bun.lock` 他)、`packages/db/drizzle/**`（生成 SQL）に `linguist-generated=true`
    - GitHub の言語統計とデフォルトの diff 折り畳み対象になる

## スコープ外 / Out of scope
- prettier / oxfmt 等のフォーマッタ設定（Phase 2 で対応）
- 既存ファイルの一括フォーマット（フォーマッタ導入時にまとめて実施）

## 検証 / Test plan
- [x] `bun run --filter '*' typecheck`
- [x] `bun test`
- [x] CI が green
- [ ] マージ後、新規ファイル作成時にエディタ側で 2-space / LF / final newline が効くことを確認

## 関連 Issue / Links
- Closes #16