### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+      include: scope
+    groups:
+      bun-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(ci)
+      include: scope
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## 概要 / Why
依存関係（Bun パッケージ・GitHub Actions）の更新を自動 PR で受けて、脆弱性対応や追従コストを下げる。手動メンテに頼らない。

## 変更内容 / What
- `.github/dependabot.yml` を追加
  - `bun` ecosystem: ルートの `bun.lock` を対象、週次、PR 上限 5、`dependencies` ラベル
  - `github-actions` ecosystem: `.github/workflows/` を対象、週次、PR 上限 5、`dependencies` ラベル
  - グルーピング: `version-updates` の minor/patch は 1 PR にまとめる（major は個別）
  - commit prefix: bun は `chore(deps)`, actions は `chore(ci)`（Conventional Commits 準拠）

## スコープ外 / Out of scope
- Dependabot 自動 merge（最初は手動レビュー運用）
- セキュリティアラート個別設定（GitHub デフォルト挙動に任せる）

## 検証 / Test plan
- [x] `bun run --filter '*' typecheck`
- [x] `bun test`
- [x] CI が green
- [ ] マージ後、Insights → Dependency graph → Dependabot で 2 ecosystem が認識されることを確認

## 関連 Issue / Links
- Closes #18

## 補足
Bun ecosystem は Dependabot で `>= v1.2.5` 以降サポート（公式 docs 確認済み）。ローカル `bun.lock` がそのまま対象になる。