### PR TITLE
ci: add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 18 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## 概要 / Why
GitHub 標準のセキュリティスキャン（CodeQL）を有効化し、JS/TS の典型的な脆弱性パターン（XSS / SQLi / Prototype Pollution / 危険な API 利用 等）を CI / 定期スキャンで検出する。

## 変更内容 / What
- `.github/workflows/codeql.yml` を追加
  - 対象言語: `javascript-typescript`（GitHub の統合言語名。JS と TS の両方をカバー）
  - クエリ: `security-and-quality`（標準の `security-extended` より広い）
  - トリガー: `push` (main) / `pull_request` / 週次 `schedule`（毎週月曜 18:00 UTC = 火曜 03:00 JST）
  - actions: `actions/checkout@v4`, `github/codeql-action/{init,analyze}@v3`
  - permissions: `actions: read` / `contents: read` / `security-events: write`
  - matrix を使い、将来言語追加時に拡張しやすい構造

## スコープ外 / Out of scope
- カスタムクエリ（必要になったら別 PR）
- `codeql-config.yml` での path filter / query 詳細チューニング（最初は default 運用）
- 他言語（Go / Python など）— v1.0.0 では JS/TS のみ

## 検証 / Test plan
- [x] CI 既存ジョブ（Typecheck / Test）が引き続き green
- [ ] 本 PR 上で `Analyze (javascript-typescript)` が成功することを確認
- [ ] マージ後、Security → Code scanning に結果が表示されることを確認

## 関連 Issue / Links
- Closes #21