### PR TITLE
chore: add .sonarcloud.properties for Automatic Analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,10 @@
+sonar.sources=apps,packages,docs
+
+sonar.tests=apps,packages
+sonar.test.inclusions=**/__tests__/**,**/*.test.ts,**/*.spec.ts
+
+sonar.exclusions=**/node_modules/**,**/dist/**,**/.turbo/**,**/coverage/**,bun.lock,packages/db/drizzle/**,**/*.d.ts
+
+sonar.cpd.exclusions=packages/db/drizzle/**
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## 概要 / Why
SonarQube Cloud の Automatic Analysis（GitHub App 連携、SONAR_TOKEN / Actions workflow なし）に対し、ソース対象範囲と除外を明示する。生成物 / lockfile を解析対象から外して誤検知を減らす。

## 変更内容 / What
- `.sonarcloud.properties` を追加
  - `sonar.sources=apps,packages,docs`
  - `sonar.tests=apps,packages`
  - `sonar.test.inclusions=**/__tests__/**,**/*.test.ts,**/*.spec.ts`
  - `sonar.exclusions`:
    - `**/node_modules/**`, `**/dist/**`, `**/.turbo/**`, `**/coverage/**`
    - `bun.lock`
    - `packages/db/drizzle/**`（drizzle-kit 生成 SQL）
    - `**/*.d.ts`
  - `sonar.cpd.exclusions=packages/db/drizzle/**`（生成 SQL は重複検出からも除外）
  - `sonar.sourceEncoding=UTF-8`

## なぜ workflow / token を作らないか
SonarQube Cloud は **Automatic Analysis** モードと **CI-based** モードがあり、本リポは前者で運用中。
- Automatic Analysis 有効時は `SONAR_TOKEN` / GitHub Actions workflow は **不要**
- `sonar-project.properties` は Automatic Analysis では **無視される**（罠）
- 設定は `.sonarcloud.properties` で行う（ANT-style wildcard 対応）

## スコープ外 / Out of scope
- coverage 連携（Automatic Analysis は coverage 取り込み非対応。必要になったら CI-based に切替）
- monorepo の複数プロジェクト分割（Automatic Analysis 非対応、現状リポ全体で 1 プロジェクト）
- branch 解析（Automatic Analysis は default + PR のみ）

## 検証 / Test plan
- [x] `bun run --filter '*' typecheck`
- [x] `bun test`
- [x] CI（Typecheck / Test / CodeQL）が green
- [ ] マージ後、SonarCloud のリポページで次回スキャン時に exclusions が効いていることを確認
  （ファイル数が減る、`packages/db/drizzle/0000_*.sql` が解析対象から外れる）

## 関連 Issue / Links
- Closes #28