### PR TITLE
chore: set up Turborepo for monorepo task pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Restore Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-typecheck-
+            ${{ runner.os }}-turbo-
       - run: bun install --frozen-lockfile
-      - run: bun run --filter '*' typecheck
+      - run: bun run typecheck
 
   test:
     name: Test
@@ -29,5 +37,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Restore Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-test-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-test-
+            ${{ runner.os }}-turbo-
       - run: bun install --frozen-lockfile
-      - run: bun test
+      - run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
       - name: Restore Turborepo cache
         uses: actions/cache@v4
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
       - name: Restore Turborepo cache
         uses: actions/cache@v4
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "supabase": "^2.98.0",
+        "turbo": "^2.9.8",
         "typescript": "^5.7.0",
       },
     },
@@ -142,6 +143,18 @@
 
     "@prep-hamster/schema": ["@prep-hamster/schema@workspace:packages/schema"],
 
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Wf/kQpVDCaWM3P5d6lKvJnqjYn/ofUBGbT4h4vRFrdC4N6B/nsun03S2kQNJJMXpXg39woeS4CI367RMU3/OAg=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.8", "", { "os": "win32", "cpu": "x64" }, "sha512-JaefWOJNBazDylAn3f+lLB34XMNu8nEBbgPRP/Ewysg81cBubGfcyyyzpQOGVuMwfaqdNAE/kitG7w3AbJn9/g=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -213,6 +226,8 @@
     "supabase": ["supabase@2.98.0", "", { "dependencies": { "bin-links": "^6.0.0", "https-proxy-agent": "^9.0.0", "node-fetch": "^3.3.2", "tar": "7.5.13" }, "bin": { "supabase": "bin/supabase" } }, "sha512-1r56wzoi6SFj+i0XHqF9rSLrjaBSrs+t6xUWn3I+UVnO9nb5ITkmaLEeGgjf7naiBUDf9rtqyRoI+5hTrezZNg=="],
 
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
+    "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "description": "備蓄管理アプリ",
+  "packageManager": "bun@1.3.13",
   "workspaces": [
     "apps/administrator/client/*",
     "apps/user/client/*",
@@ -11,14 +12,19 @@
     "packages/*"
   ],
   "scripts": {
-    "typecheck": "bun run --filter '*' typecheck",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
     "format": "bun run --filter '*' format",
     "lint": "bun run --filter '*' lint",
-    "test": "bun run --filter '*' test"
+    "typecheck:bun": "bun run --filter '*' typecheck",
+    "test:bun": "bun run --filter '*' test"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "supabase": "^2.98.0",
+    "turbo": "^2.9.8",
     "typescript": "^5.7.0"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.base.json", ".env.*local"],
+  "tasks": {
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "inputs": [
+        "src/**",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json"
+      ],
+      "outputs": []
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json"
+      ],
+      "outputs": []
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["tsconfig.base.json", ".env.*local"],
+  "globalDependencies": ["tsconfig.base.json", "bun.lock"],
   "tasks": {
     "typecheck": {
+      "description": "型検査 (tsc --noEmit)",
       "dependsOn": ["^typecheck"],
       "inputs": [
         "src/**",
@@ -13,6 +14,7 @@
       "outputs": []
     },
     "build": {
+      "description": "ビルド成果物を持つ package 用 (現状は枠のみ)",
       "dependsOn": ["^build"],
       "inputs": [
         "src/**",
@@ -23,7 +25,8 @@
       "outputs": ["dist/**"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "description": "テスト (Bun は TS を直接解決するため ^build ではなく ^typecheck に依存)",
+      "dependsOn": ["^typecheck"],
       "inputs": [
         "src/**",
         "tsconfig.json",
@@ -33,8 +36,10 @@
       "outputs": []
     },
     "dev": {
+      "description": "開発用永続タスク (cache 無効、env はキャッシュキーに影響させない)",
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "passThroughEnv": ["DATABASE_URL", "PORT", "PREP_HAMSTER_*"]
     }
   }
 }


### PR DESCRIPTION
## 概要 / Why
現状 `bun run --filter '*' typecheck` 等は変更がない package も全部走り、依存順も bun は把握しない。Turborepo を入れて以下を解決する：
- 影響変更のみ実行（cache hit 時はスキップ）
- パッケージ間の依存順 (schema → db → api → api-client → cli) を自動解決
- ローカル + CI でキャッシュ共有

## 変更内容 / What
### `turbo.json`（v2 `tasks` 形式）
- `typecheck` / `build` / `test`: `dependsOn: ["^<task>"]` で依存パッケージから順に
- `dev`: `cache: false` + `persistent: true`
- `inputs` を `src/**` `tsconfig*.json` `package.json` に絞り、cache key の安定化
- `globalDependencies` に `tsconfig.base.json` を入れ、base 変更時は全 cache invalidate

### ルート `package.json`
- `packageManager: "bun@1.3.13"` を追加（turbo v2 が要求）
- devDependency に `turbo@^2.9.8`
- scripts:
  - `typecheck` / `test` / `build` / `dev` → `turbo run *` に置換
  - 旧 `bun run --filter '*' *` は `*:bun` として保持（debug 用）

### `.github/workflows/ci.yml`
- `bun run typecheck` / `bun run test` に切替（実体は turbo）
- `actions/cache@v4` で `.turbo/cache` を保存・復元
  - `key`: `runner.os - turbo - job - sha`
  - `restore-keys` で job 種別 → OS と段階的 fall back

## ローカル動作確認
- 1 回目（cold）: `bun run typecheck` → 6 packages 通過、3.6s
- 2 回目（warm）: `>>> FULL TURBO` 6/6 cache hit、75ms

## スコープ外 / Out of scope
- Turborepo Remote Cache（Vercel / 自前 S3）
- 各 package の `package.json` script 追加
- typescript-go 連携（別 Issue 側で `tsc → tsgo` 差し替え）

## 検証 / Test plan
- [x] ローカル typecheck cold 通過
- [x] ローカル typecheck warm = FULL TURBO
- [x] ローカル test 通過
- [ ] CI 上で typecheck / test が green
- [ ] CI 2 回目以降で turbo cache hit 件数が増える

## 関連 Issue / Links
- Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインのキャッシュ戦略を改善し、ビルド処理の効率化を実現しました。
  * ビルドシステムをTurboベースの構成に統一し、開発ワークフローを強化しました。
  * パッケージマネージャーをプロジェクト設定で明示的に指定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->