### PR TITLE
chore: add Docker setup for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+**/node_modules
+**/dist
+**/.turbo
+**/.cache
+**/.next
+**/.expo
+**/.expo-shared
+**/.tanstack
+**/.output
+**/.vinxi
+**/coverage
+**/.tsbuildinfo
+**/*.tsbuildinfo
+
+.git
+.github
+.vscode
+.idea
+
+.env
+.env.local
+.env.*.local
+
+*.log
+**/*.log
+
+# repository docs / config not needed in image
+docs
+README.md
+.editorconfig
+.gitattributes
+.gitignore
+.coderabbit.yaml
+.sonarcloud.properties
+sonar-project.properties
+.mise.toml
+
+# tests / fixtures (image is runtime only)
+**/__tests__
+**/*.test.ts
+**/*.spec.ts
+
+# supabase local dev artifacts (host-side only)
+supabase/.branches
+supabase/.temp

--- a/README.md
+++ b/README.md
@@ -79,3 +79,47 @@ Supabase ローカルスタックの停止: `bunx supabase stop`
 - **IDE 言語サーバー**: 本家 `tsc`（`typescript@^5.7` を devDep に維持）。tsgo は LSP の機能パリティが未完成のため
 
 切替対象は v1.0.0 では `--noEmit` のみ。`declaration` / `declarationMap` / `incremental` などの emit パスは tsgo 側でまだ「進行中」とされているため、必要になったら再評価する。
+
+## ローカルで API を Docker で動かす
+
+API を本番（Cloud Run）に近い環境で確認したい時 / Hot reload で開発したい時の 2 モードを用意している。
+DB は引き続き Supabase CLI（host 上の `:54322`）に接続する前提。
+
+### 前提
+
+- `bunx supabase start` で Postgres が起動済み
+- Linux の素の Docker daemon を使う場合、`host.docker.internal` 解決のため `compose.yaml` の `extra_hosts` を入れている。Docker Desktop / WSL では自動で解決される。
+
+### dev プロファイル（hot reload）
+
+ソースを bind mount し、コンテナ内で `bun install` → `bun --watch` で起動する。
+
+```sh
+docker compose --profile dev up
+```
+
+- `localhost:3000` で API、`/health` が 200 を返せば疎通
+- `node_modules` は named volume (`api_node_modules`) に隔離して host の OS 差分を回避
+
+### prod プロファイル（本番再現）
+
+`apps/core/api/Dockerfile` をビルドして、非 root ユーザーで起動する。
+
+```sh
+docker compose --profile prod up --build
+```
+
+- 同じ Dockerfile が将来 Cloud Run へのデプロイにも使われる
+- `HEALTHCHECK` で `/health` を 30s ごとに監視
+
+### 動作確認
+
+```sh
+# 別ターミナルから
+curl -s http://localhost:3000/health
+# → {"ok":true}
+
+# CLI で叩く（PREP_HAMSTER_USER_ID は stub 認証ヘッダ用）
+PREP_HAMSTER_USER_ID=00000000-0000-0000-0000-000000000001 \
+  bun run --filter @prep-hamster/cli-user start stock list
+```

--- a/apps/core/api/Dockerfile
+++ b/apps/core/api/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+ARG BUN_VERSION=1
+FROM oven/bun:${BUN_VERSION}-slim AS base
+WORKDIR /app
+ENV CI=true
+
+# --- deps: workspace package.json をすべて配置して bun install ---
+# Bun は workspace を per-package node_modules の symlink で解決するため、
+# root の node_modules だけでなく各 workspace の node_modules も生成される。
+FROM base AS deps
+COPY package.json bun.lock ./
+COPY apps/core/api/package.json apps/core/api/package.json
+COPY apps/user/client/cli/package.json apps/user/client/cli/package.json
+COPY apps/administrator/client/cli/package.json apps/administrator/client/cli/package.json
+COPY packages/api-client/package.json packages/api-client/package.json
+COPY packages/db/package.json packages/db/package.json
+COPY packages/schema/package.json packages/schema/package.json
+RUN bun install --frozen-lockfile
+
+# --- source: deps の node_modules を引き継いだまま、API が必要とする
+#     workspace のソース実体を載せる ---
+FROM deps AS source
+COPY tsconfig.base.json ./
+COPY apps/core/api ./apps/core/api
+COPY packages/db ./packages/db
+COPY packages/schema ./packages/schema
+
+# --- runtime: 非 root ユーザーで起動、HEALTHCHECK で /health 監視 ---
+FROM base AS runtime
+ENV NODE_ENV=production \
+    PORT=3000
+
+RUN groupadd --system --gid 1001 app \
+ && useradd --system --uid 1001 --gid app --no-create-home --shell /usr/sbin/nologin app
+
+COPY --from=source --chown=app:app /app /app
+
+USER app
+WORKDIR /app/apps/core/api
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD bun --eval "fetch('http://localhost:' + (process.env.PORT || 3000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["bun", "run", "src/index.ts"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,38 @@
+services:
+  # production-like: build the Dockerfile, run as non-root, /health probed
+  # `docker compose --profile prod up --build`
+  api:
+    build:
+      context: .
+      dockerfile: apps/core/api/Dockerfile
+    image: prep-hamster-api:local
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@host.docker.internal:54322/postgres
+      PORT: "3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    profiles: ["prod"]
+
+  # dev: bind-mount source, hot reload via `bun --watch`
+  # node_modules は named volume にして host の OS 差分を回避
+  # `docker compose --profile dev up`
+  api-dev:
+    image: oven/bun:1-slim
+    working_dir: /app
+    command: ["sh", "-c", "bun install --frozen-lockfile && bun run --watch apps/core/api/src/index.ts"]
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@host.docker.internal:54322/postgres
+      PORT: "3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - .:/app
+      - api_node_modules:/app/node_modules
+    profiles: ["dev"]
+
+volumes:
+  api_node_modules:

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,8 @@ services:
   api-dev:
     image: oven/bun:1-slim
     working_dir: /app
-    command: ["sh", "-c", "bun install --frozen-lockfile && bun run --watch apps/core/api/src/index.ts"]
+    command:
+      ["sh", "-c", "bun install --frozen-lockfile && bun run --watch apps/core/api/src/index.ts"]
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## 概要 / Why
ローカル動作確認の手順を統一する。現状は `supabase start` + `bun run dev`（host 起動）の二段で、再現性 / 本番（Cloud Run）との差分が見えづらい。
Bun + Linux 環境で API を Docker 起動できるようにし、本番デプロイにも流用できる Dockerfile を持つ。

## 変更内容 / What

### `apps/core/api/Dockerfile`（multi-stage、production-grade）
- ベース: `oven/bun:1-slim`
- **deps stage**: workspace の `package.json` を全配置し `bun install --frozen-lockfile`
  - Bun は workspace を per-package node_modules の symlink で解決するため、各 workspace の `node_modules/` がここで生成される
- **source stage**: `FROM deps` で deps を継承、API が必要とする workspace（db / schema）のソース実体だけ載せる
- **runtime stage**: 非 root user (uid 1001) で起動、`HEALTHCHECK` で `/health` を 30s 間隔で監視

### `.dockerignore`（リポルート）
- `node_modules` / `dist` / `.turbo` / `.git` / `.env*` / docs / lockfile 以外の不要ファイルを除外

### `compose.yaml`（profile で 2 モード）
- **`docker compose --profile prod up --build`**
  - Dockerfile をビルドして起動。本番再現用
- **`docker compose --profile dev up`**
  - `oven/bun:1-slim` を直接起動、ソース bind mount + named volume (`api_node_modules`) で `bun --watch` 動作
  - 起動時に `bun install --frozen-lockfile` を実行（初回のみ重い、以降 named volume にキャッシュ）

### README に「ローカルで API を Docker で動かす」セクション追加
- dev / prod の使い分け、`host.docker.internal` 注意、`/health` 疎通確認、CLI からの動作確認手順

## ローカル動作確認
```
$ docker buildx build -f apps/core/api/Dockerfile -t prep-hamster-api:local .
... (success, 501MB)

$ docker run -d -p 13000:3000 -e DATABASE_URL=... prep-hamster-api:local
$ curl http://localhost:13000/health
{"ok":true}
```

## 設計判断
- **DB は compose に含めない**: supabase CLI が Docker stack で起動済みのため、重複させると port 競合 / migration 重複で混乱する
- **per-package node_modules を保持するため `FROM deps`**: 別 stage で `COPY --from=deps /app/node_modules` だと workspace symlinks (per-package) が落ちて `Cannot find module '@prep-hamster/db'` で起動失敗する。実際にハマった
- **HEALTHCHECK は `bun --eval`**: oven/bun:slim には curl/wget が無いため Bun の fetch を使用

## スコープ外 / Out of scope
- Distroless / scratch ベースの最適化（Cloud Run cold start 改善時に別 Issue）
- admin / user web の Dockerfile（Phase 4 以降）
- supabase CLI 代替として compose に Postgres を持たせる構成
- BuildKit cache mount の最適化

## 検証 / Test plan
- [x] `docker buildx build apps/core/api/Dockerfile` 成功
- [x] `docker run prep-hamster-api:local` で起動、`/health` が `{"ok":true}` 200
- [x] `docker compose --profile prod config` / `--profile dev config` 構文 OK
- [ ] `docker compose --profile dev up` で hot reload 動作確認（user 環境）
- [ ] CI green

## 関連 Issue / Links
- Closes #32