### PR TITLE
chore(ci): add labeling policy + auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,80 @@
+# Label rules for actions/labeler@v5
+# See: .github/labeling-policy.md
+
+# --- Apps ---
+"changed/apps/core/api":
+  - changed-files:
+      - any-glob-to-any-file: "apps/core/api/**"
+
+"changed/apps/user/client/cli":
+  - changed-files:
+      - any-glob-to-any-file: "apps/user/client/cli/**"
+
+"changed/apps/user/client/mobile":
+  - changed-files:
+      - any-glob-to-any-file: "apps/user/client/mobile/**"
+
+"changed/apps/administrator/client/cli":
+  - changed-files:
+      - any-glob-to-any-file: "apps/administrator/client/cli/**"
+
+"changed/apps/administrator/client/web":
+  - changed-files:
+      - any-glob-to-any-file: "apps/administrator/client/web/**"
+
+# --- Packages ---
+"changed/packages/schema":
+  - changed-files:
+      - any-glob-to-any-file: "packages/schema/**"
+
+"changed/packages/db":
+  - changed-files:
+      - any-glob-to-any-file: "packages/db/**"
+
+"changed/packages/api-client":
+  - changed-files:
+      - any-glob-to-any-file: "packages/api-client/**"
+
+"changed/packages/jan-api":
+  - changed-files:
+      - any-glob-to-any-file: "packages/jan-api/**"
+
+"changed/packages/sync":
+  - changed-files:
+      - any-glob-to-any-file: "packages/sync/**"
+
+# --- Docs ---
+"changed/docs":
+  - changed-files:
+      - any-glob-to-any-file: "docs/**"
+
+# --- CI / GitHub config ---
+"changed/ci":
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+# --- Docker ---
+"changed/docker":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Dockerfile"
+          - "compose.yaml"
+          - "compose.*.yaml"
+          - ".dockerignore"
+          - "apps/**/Dockerfile"
+          - "apps/**/.dockerignore"
+
+# --- Supabase local stack ---
+"changed/supabase":
+  - changed-files:
+      - any-glob-to-any-file: "supabase/**"
+
+# --- Build / monorepo config (root level) ---
+"changed/build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "turbo.json"
+          - "tsconfig.base.json"
+          - "package.json"
+          - "bun.lock"
+          - ".mise.toml"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-# Label rules for actions/labeler@v5
+# Label rules for actions/labeler v6 (workflow pins SHA)
 # See: .github/labeling-policy.md
 
 # --- Apps ---

--- a/.github/labeling-policy.md
+++ b/.github/labeling-policy.md
@@ -1,0 +1,189 @@
+# GitHub Label Policy
+
+## Overview
+
+GitHub Issue / PR label naming conventions and usage rules for the prep-hamster repository. Mirrors `micoworks/delivery-foundation` のラベル体系を採用しつつ、本リポ固有のニーズに合わせて `needs/coderabbit-review` を追加。
+
+## Principles
+
+1. ラベルは `prefix/name` 形式を標準とする
+2. 自動付与（`changed/`）と手動付与（`scope/`, `type/`, `priority/`, `effort/`, `needs/`, `status/`）を prefix で明確に分離
+3. CI / CodeRabbit / GitHub default 等の例外ラベルは末尾セクションに明記する
+4. 命名規約に合わない既存ラベルは `prefix/name` に rename する（rename は Issue/PR の関連を保つ）
+
+## Label Prefixes
+
+### `changed/` -- Automated (PR only)
+
+`actions/labeler` が変更ファイルパスから自動付与する。**手動で付けない。**
+
+ラベル名はディレクトリ構造をそのままミラーする（新パッケージ追加時の判断を機械化するため）。
+
+| Label | Trigger path |
+|---|---|
+| `changed/apps/core/api` | `apps/core/api/**` |
+| `changed/apps/user/client/cli` | `apps/user/client/cli/**` |
+| `changed/apps/user/client/mobile` | `apps/user/client/mobile/**` |
+| `changed/apps/administrator/client/cli` | `apps/administrator/client/cli/**` |
+| `changed/apps/administrator/client/web` | `apps/administrator/client/web/**` |
+| `changed/packages/schema` | `packages/schema/**` |
+| `changed/packages/db` | `packages/db/**` |
+| `changed/packages/api-client` | `packages/api-client/**` |
+| `changed/packages/jan-api` | `packages/jan-api/**` |
+| `changed/packages/sync` | `packages/sync/**` |
+| `changed/docs` | `docs/**` |
+| `changed/ci` | `.github/**` |
+| `changed/docker` | `Dockerfile`, `compose.yaml`, `compose.*.yaml`, `.dockerignore`, `apps/**/Dockerfile`, `apps/**/.dockerignore` |
+| `changed/supabase` | `supabase/**` |
+| `changed/build` | `turbo.json`, `tsconfig.base.json`, root `package.json`, `bun.lock`, `.mise.toml` |
+
+新パッケージ追加時はこの表に行を追加し、同時に `.github/labeler.yml` も更新する。命名は `changed/` + リポルートからの相対パス。
+
+### `scope/` -- Manual (Issue)
+
+影響範囲を示す。本リポは個人開発だが、将来チーム運用を考慮して prefix 体系は揃える。
+
+| Label | Description |
+|---|---|
+| `scope/apps` | apps/ 配下のアプリケーション |
+| `scope/infrastructure` | CI / Docker / Cloud Run / Supabase / 設定ファイル |
+| `scope/packages` | packages/ 配下の共通パッケージ |
+
+### `type/` -- Manual (Issue / PR)
+
+変更や課題の種類を示す。**Conventional Commits の type と 1:1 対応**。
+
+| Label | Conventional Commits | Description |
+|---|---|---|
+| `type/bug` | `fix:` | バグ修正 |
+| `type/enhancement` | `feat:` | 新機能・機能改善 |
+| `type/refactoring` | `refactor:` | 振る舞いを変えないリファクタ |
+| `type/tech-debt` | `refactor:` / `chore:` | 設計・アーキ負債、より広範な書き換え |
+| `type/documentation` | `docs:` | ドキュメント変更 |
+| `type/chore` | `chore:` | ビルド / CI / tooling / 設定の変更 |
+| `type/test` | `test:` | テストの追加・修正 |
+
+### `priority/` -- Manual (Issue)
+
+トリアージ用の緊急度。将来 GitHub Projects のカスタムフィールドに移行する可能性あり。
+
+| Label | Description |
+|---|---|
+| `priority/critical` | 即時対応必須 |
+| `priority/high` | 現在のスプリントで対応 |
+| `priority/medium` | 近いうちに対応 |
+| `priority/low` | バックログ、余裕があるとき |
+
+### `needs/` -- Manual (Issue / PR)
+
+着手・マージの前提が欠けていることを示す。`status/`（現在の状態）と異なり、`needs/` は **次に進むために必要なもの** を表す。
+
+| Label | Description |
+|---|---|
+| `needs/reproduction` | 再現手順が報告者から必要 |
+| `needs/information` | 追加のコンテキスト・詳細が必要 |
+| `needs/investigation` | 計画前に技術調査が必要 |
+| `needs/coderabbit-review` | **本リポ固有**: CodeRabbit のレビューを必ず一度は通してからマージする |
+
+#### `needs/coderabbit-review` の運用
+
+本リポは OSS free tier で CodeRabbit を使用しており、レビューに 1/h の rate limit がある。通常はベストエフォートで運用するが、**重要な PR では必ずレビューを通したい**。それを明示するためのラベル。
+
+**付与基準（目安）**:
+- 機能実装系（`type/enhancement`）の PR / Issue
+- インフラ / セキュリティ影響あり（Dockerfile, compose, DB schema, RLS 関連）
+- ライブラリの major bump（Bun, Hono, Drizzle, Zod 等の major version 上げ）
+- 本番デプロイ周り（Cloud Run workflow, secret 管理）
+- 設計判断が大きい PR（OpenAPI ライブラリ採用、typescript-go への切替 等）
+
+**付与しない目安**:
+- 単純な docs 更新
+- 1 ヶ所の typo 修正
+- 自動生成ファイル（drizzle migration, lockfile）の更新のみ
+
+**運用ルール**:
+1. 該当 PR で CodeRabbit が `Review skipped` / rate limit hit になった場合、**マージしない**
+2. 45 分以上待ってから `@coderabbitai review` をコメント投稿して再レビュー
+3. レビュー結果を反映 / resolve してからマージ
+
+### `status/` -- Manual (PR)
+
+GitHub の draft / ready 機構を超えた PR の状態を示す。
+
+| Label | Description |
+|---|---|
+| `status/blocked` | 外部依存でブロック |
+| `status/in-progress` | 作業中（draft ではないが完了でもない） |
+| `status/needs-testing` | 手動 / 環境テスト待ち |
+
+### `effort/` -- Manual (Issue)
+
+実装コストの見積もり。スプリント計画 / トリアージで使う。
+
+| Label | Description |
+|---|---|
+| `effort/small` | 数時間。1 ファイル or 軽微な設定変更 |
+| `effort/medium` | 1-2 日。複数ファイル、ある程度のテストが必要 |
+| `effort/large` | 3 日以上。設計判断、横断的変更、まとまった検証が必要 |
+
+## Exceptions
+
+`prefix/name` 規約に従わないラベル。外部ツール管理、または GitHub 標準のトリアージ用途。
+
+### Dependency management
+
+- `dependencies` -- Dependabot が PR に自動付与
+
+### CodeRabbit (将来追加される可能性)
+
+- `can-close` / `needs-action` / `needs-review` 等 -- delivery-foundation で使用例あり、本リポでは未導入
+
+### GitHub default (triage)
+
+GitHub の組み込みラベル。標準トリアージワークフロー用に維持。
+
+- `duplicate`
+- `invalid`
+- `wontfix`
+- `good first issue`
+- `help wanted`
+- `question`
+
+## Operations
+
+### 新ラベルの追加
+
+1. 本ドキュメントの該当 prefix セクションの表に追加
+2. `gh label create "prefix/name" --color "<hex>" --description "..."` で実体を作成
+3. `changed/` 系の場合は `.github/labeler.yml` にも対応する glob ルールを追加
+
+### `changed/` ラベルの色
+
+`#bfdadc`（明るいティール）で統一。ディレクトリミラーなので個別に色を変えない。
+
+### `scope/` / `priority/` / `needs/` 等の色
+
+| Prefix | Color | 意図 |
+|---|---|---|
+| `scope/*` | `#c5def5` | 中立的な情報ラベル |
+| `type/bug` | `#d73a4a` | GitHub default 維持 |
+| `type/enhancement` | `#a2eeef` | GitHub default 維持 |
+| `type/documentation` | `#0075ca` | GitHub default 維持 |
+| `type/refactoring` | `#fbca04` | 注意喚起 |
+| `type/tech-debt` | `#f9a825` | 注意喚起（より濃い） |
+| `type/chore`, `type/test` | `#ededed` | グレー（軽微変更） |
+| `priority/critical` | `#b60205` | 強い赤 |
+| `priority/high` | `#d93f0b` | オレンジ |
+| `priority/medium` | `#fbca04` | 黄色 |
+| `priority/low` | `#0e8a16` | 緑 |
+| `needs/*`（投資情報系） | `#f9d0c4` | 桃色 |
+| `needs/coderabbit-review` | `#ff9966` | 桃色より濃いオレンジ（区別用） |
+| `effort/small/medium/large` | `#bfd4f2` / `#d4c5f9` / `#7057ff` | 紫グラデ |
+| `status/blocked` | `#b60205` | 強い赤 |
+| `status/in-progress`, `status/needs-testing` | `#fbca04` | 黄色 |
+
+## Related Files
+
+- `.github/labeler.yml` -- `actions/labeler` のルール定義（`changed/` ラベルと同期させる）
+- `.github/workflows/labeler.yml` -- `pull_request_target` で labeler を起動する workflow
+- `.github/PULL_REQUEST_TEMPLATE.md` -- PR 作成時に `needs/coderabbit-review` 付与判定のチェック欄を含める（後続改善）

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
     name: Apply changed/* labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Apply changed/* labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
## 概要 / Why
`micoworks/delivery-foundation#1472` のラベル命名規約（`prefix/name`）を本リポにも移植する。最初から整った体系で運用することで、ラベルが無秩序に増えるのを防ぐ。
加えて、本リポ固有の `needs/coderabbit-review` を追加し、重要 PR では CodeRabbit のレビュー完了を必須にする運用ゲートを作る（OSS free tier の rate limit を許容しつつ、必要な PR は待つ）。

## 変更内容 / What

### `.github/labeling-policy.md`（命名規約）
- `prefix/name` 形式を標準化
- prefix: `changed/`（自動）/ `scope/` / `type/` / `priority/` / `needs/` / `status/` / `effort/`（手動）
- 例外: `dependencies`（Dependabot）、GitHub default（`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wanted`, `question`）
- **`needs/coderabbit-review`** の付与基準と運用ルール明記
  - 機能実装 / インフラ・セキュリティ影響 / lib major bump / 本番デプロイ / 設計判断大、に付与
  - rate limit hit 時は 45 分待って `@coderabbitai review` で再走 → 反映してマージ

### `.github/labeler.yml`（自動付与ルール）
- apps / packages / docs / ci / docker / supabase / build を網羅
- ディレクトリ構造をミラーした命名（例: `changed/apps/core/api`）
- 新パッケージ追加時は `changed/` 行を 1 つ追加するだけ

### `.github/workflows/labeler.yml`（workflow）
- `pull_request_target` (opened/synchronize/reopened) で起動
- `actions/labeler@v5` + `sync-labels: true`
- permissions: `contents: read` / `pull-requests: write`

### ラベル本体
- 既に **`gh label create` で 46 個作成済み**（rename 3 件 + 新規 36 件 + 既存維持 7 件）
- 既存 Issue（open + closed）にも backfill 済み

## なぜ `needs/coderabbit-review` なのか
本リポは OSS free tier で CodeRabbit を運用しており、1 review/h の rate limit がある。**全 PR で必須にするとマージが詰まる** ため、ラベルで明示的に「このPRはレビュー必須」を選別する設計。

## スコープ外 / Out of scope
- 既存 PR への自動 backfill（次の PR 以降から自動付与開始）
- GitHub Projects 連携（`priority/*` を Project field 化）
- stale bot
- CodeRabbit 側で `needs/coderabbit-review` の有無で挙動を変える設定（別途調査）

## 検証 / Test plan
- [x] `bun run typecheck` / `bun run test` 既存 CI が green
- [ ] **本 PR を CodeRabbit にレビューさせる**（`needs/coderabbit-review` 対象。レビュー結果を反映してからマージ）
- [ ] マージ後、次の PR で `actions/labeler` が `changed/.github/**` → `changed/ci` を自動付与することを確認
- [ ] マージ後、`changed/docker` などのパス別ラベルが正しく付くか観察

## 関連 Issue / Links
- Closes #45
- 元: `micoworks/delivery-foundation#1472`（labeling-policy 策定 PR）

## レビューガイド
- `labeling-policy.md` の `needs/coderabbit-review` セクションが意図通りか
- `labeler.yml` の glob パターン（特に `changed/docker` の複数パス指定 / `changed/build` の root level config の網羅）
- `workflow` の permissions が `pull_request_target` に対して妥当か

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHubの自動ラベル割り当て機能を実装しました。プルリクエストのファイル変更に基づいて、標準化されたラベルが自動的に付与されるようになります。

* **Documentation**
  * ラベル命名規約のドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->