### PR TITLE
chore: introduce lefthook with commit-msg validation

### DIFF
--- a/.lefthook/commit-msg/commitlint.sh
+++ b/.lefthook/commit-msg/commitlint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Conventional Commits 形式の最低限チェック
+#
+# 受理:
+#   <type>: <subject>
+#   <type>(<scope>): <subject>
+#   <type>!: <subject>           (breaking change)
+#   <type>(<scope>)!: <subject>
+# type: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+#
+# Merge / Revert / Fixup などの自動生成 message は除外。
+#
+# 引数: $1 = .git/COMMIT_EDITMSG のパス（lefthook の {1} placeholder で渡される）
+
+set -eu
+
+msg_file="${1:?commit-msg hook requires the message file path}"
+first_line="$(head -n 1 "$msg_file")"
+
+# 自動生成 / 中断系メッセージはスキップ
+case "$first_line" in
+  "Merge "* | "Revert "* | "fixup! "* | "squash! "* | "amend! "*) exit 0 ;;
+  "") exit 0 ;;
+esac
+
+# Conventional Commits の最低形
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'
+
+if [[ ! "$first_line" =~ $pattern ]]; then
+  cat >&2 <<EOF
+
+✗ Commit message must follow Conventional Commits.
+
+  受け取り:
+    "$first_line"
+
+  期待形式:
+    <type>(<scope>)?!?: <subject>
+
+  type: feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+
+  例:
+    feat(api): add stock list endpoint
+    fix: handle empty groupId in useStock
+    chore!: drop Bun 1.2 support
+    docs(stock): clarify FIFO policy
+
+EOF
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ mise install
 bun install
 ```
 
+`bun install` で [lefthook](https://lefthook.dev/) の git hook が自動セットアップされる（`commit-msg` でコミットメッセージを Conventional Commits 形式かチェック）。
+
+- 個別 commit で hook をスキップ: `LEFTHOOK=0 git commit -m "..."`
+- CI 中（`CI=true`）は lefthook が自動で skip するため何もしなくてよい
+
 ## ローカル DB（Supabase + Drizzle）
 
 ローカル環境では Supabase CLI で Postgres / Auth / Storage を Docker で立て、Drizzle がスキーママイグレーションを管理する。

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "prep-hamster",
       "devDependencies": {
         "@types/bun": "latest",
+        "lefthook": "^2.1.6",
         "supabase": "^2.98.0",
         "turbo": "^2.9.8",
         "typescript": "^5.7.0",
@@ -196,6 +197,28 @@
     "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "https-proxy-agent": ["https-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g=="],
+
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+# https://lefthook.dev/configuration/
+#
+# 運用ルール:
+# - CI 中は CI=true により lefthook 側で自動 skip される
+# - 個別 hook を一時 skip したいときは `LEFTHOOK=0 git commit ...`
+# - pre-commit / pre-push は oxfmt / oxlint 導入後（Phase 2-2 / 2-3）に追加する
+
+commit-msg:
+  jobs:
+    - name: commitlint
+      run: bash .lefthook/commit-msg/commitlint.sh {1}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "lefthook install",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "build": "turbo run build",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "lefthook": "^2.1.6",
     "supabase": "^2.98.0",
     "turbo": "^2.9.8",
     "typescript": "^5.7.0"


### PR DESCRIPTION
## 概要 / Why
git hook をローカルで強制したい。最小構成として **`commit-msg` で Conventional Commits 形式の検証** から導入する。labeling-policy の `type/*` と Conventional Commits を 1:1 対応させているため、コミット時点で形式を担保すると後段（PR 自動ラベリング、release-notes 生成など）に効く。

`pre-commit` / `pre-push` は oxfmt / oxlint を入れた後（Phase 2-2 / 2-3）に追加する想定。

## 変更内容 / What
1. **devDep に `lefthook@^2.1.6`**
2. **`lefthook.yml`**
   - `commit-msg` の jobs に commitlint.sh を 1 つ
   - `pre-commit` / `pre-push` は将来追加するためのコメントを残す
3. **`.lefthook/commit-msg/commitlint.sh`** (実行権限付き)
   - bash + 正規表現で Conventional Commits 最低形を検証
   - 受理: `<type>(<scope>)?!?: <subject>` で type が `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
   - 自動生成 / 中断系メッセージ（`Merge ...` / `Revert ...` / `fixup! ...` / `squash! ...` / `amend! ...`）はスキップ
   - 失敗時は **日本語の error message** + 受け取り表示 + 例示
4. **`package.json` の `scripts.postinstall`** に `lefthook install`
   - `bun install` で hook が自動セットアップ
5. **README** に運用ルール（`LEFTHOOK=0` で個別 skip、CI 中は自動 skip）を追記

## 設計判断
- Husky ではなく lefthook（Go 実装、並列実行、Bun との親和性）
- commitlint パッケージは入れず、bash 正規表現で最低限の検証のみ。後で本格化したくなったら別 Issue で `commitlint` パッケージ採用検討
- `LEFTHOOK=0` で個別スキップ可能なことを README に明記（緊急時の逃げ道）
- monorepo 全体に効かせる前提で `root:` は使わない

## ローカル動作確認
```sh
$ git commit -m "this is a bad commit message"
✗ Commit message must follow Conventional Commits.
  ...
exit status 1   ← 拒否

$ git commit -m "chore: introduce lefthook with commit-msg validation"
🥊 lefthook v2.1.6  hook: commit-msg
✔️ commitlint (0.00 seconds)
[branch hash] chore: introduce lefthook with commit-msg validation   ← 受理
```

`Merge` / `Revert` / `fixup!` 等は意図通りスキップされる。

## スコープ外 / Out of scope
- `pre-commit` / `pre-push` hook 追加（oxfmt / oxlint 導入時）
- commitlint パッケージ採用（必要になったら別 Issue）
- Husky からの移行（最初から lefthook）

## 検証 / Test plan
- [x] bad commit message → hook が拒否（exit 1）
- [x] valid commit message (`feat:`, `fix:`, `chore:` 等) → 受理
- [x] `chore!: ...` (breaking) → 受理
- [x] `Merge ...` / `Revert ...` → スキップ
- [x] `bun install` で `lefthook install` が走り `.git/hooks/commit-msg` が設置される
- [ ] CI 中は `CI=true` により hook が自動 skip される（CI 上で確認）
- [x] CI（typecheck / test / CodeQL）が green

## 関連 Issue / Links
- Closes #47
- 元: #36 (research, deepwiki-cli の Lefthook 調査結果コメント参照)