### PR TITLE
chore: introduce oxlint for fast Rust-based linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,14 @@ jobs:
             ${{ runner.os }}-turbo-
       - run: bun install --frozen-lockfile
       - run: bun run test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - run: bun install --frozen-lockfile
+      - run: bunx oxlint --format=github

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "oxc",
+    "import",
+    "promise",
+    "node",
+    "unicorn"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "perf": "error",
+    "restriction": "off",
+    "pedantic": "off",
+    "style": "off",
+    "nursery": "off"
+  },
+  "rules": {
+    "no-console": "off",
+    "no-empty-pattern": "error",
+    "import/no-cycle": "warn",
+    "unicorn/no-process-exit": "off",
+    "unicorn/prefer-node-protocol": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
+      "rules": {
+        "no-empty": "off"
+      }
+    },
+    {
+      "files": ["packages/db/drizzle.config.ts"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
+    }
+  ],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/.turbo/**",
+    "packages/db/drizzle/**",
+    "supabase/.branches/**",
+    "supabase/.temp/**"
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "lefthook": "^2.1.6",
+        "oxlint": "^1.62.0",
         "supabase": "^2.98.0",
         "turbo": "^2.9.8",
         "typescript": "^5.7.0",
@@ -132,6 +133,44 @@
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
+
     "@prep-hamster/api": ["@prep-hamster/api@workspace:apps/core/api"],
 
     "@prep-hamster/api-client": ["@prep-hamster/api-client@workspace:packages/api-client"],
@@ -231,6 +270,8 @@
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
+
+    "oxlint": ["oxlint@1.62.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.62.0", "@oxlint/binding-android-arm64": "1.62.0", "@oxlint/binding-darwin-arm64": "1.62.0", "@oxlint/binding-darwin-x64": "1.62.0", "@oxlint/binding-freebsd-x64": "1.62.0", "@oxlint/binding-linux-arm-gnueabihf": "1.62.0", "@oxlint/binding-linux-arm-musleabihf": "1.62.0", "@oxlint/binding-linux-arm64-gnu": "1.62.0", "@oxlint/binding-linux-arm64-musl": "1.62.0", "@oxlint/binding-linux-ppc64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-gnu": "1.62.0", "@oxlint/binding-linux-riscv64-musl": "1.62.0", "@oxlint/binding-linux-s390x-gnu": "1.62.0", "@oxlint/binding-linux-x64-gnu": "1.62.0", "@oxlint/binding-linux-x64-musl": "1.62.0", "@oxlint/binding-openharmony-arm64": "1.62.0", "@oxlint/binding-win32-arm64-msvc": "1.62.0", "@oxlint/binding-win32-ia32-msvc": "1.62.0", "@oxlint/binding-win32-x64-msvc": "1.62.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,9 +3,16 @@
 # 運用ルール:
 # - CI 中は CI=true により lefthook 側で自動 skip される
 # - 個別 hook を一時 skip したいときは `LEFTHOOK=0 git commit ...`
-# - pre-commit / pre-push は oxfmt / oxlint 導入後（Phase 2-2 / 2-3）に追加する
+# - pre-commit に oxfmt はまだ未導入（Phase 2-3 で追加）
 
 commit-msg:
   jobs:
     - name: commitlint
       run: bash .lefthook/commit-msg/commitlint.sh {1}
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: oxlint
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs}"
+      run: bunx oxlint {staged_files}

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "format": "bun run --filter '*' format",
-    "lint": "bun run --filter '*' lint",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
     "typecheck:bun": "bun run --filter '*' typecheck",
     "test:bun": "bun run --filter '*' test"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "lefthook": "^2.1.6",
+    "oxlint": "^1.62.0",
     "supabase": "^2.98.0",
     "turbo": "^2.9.8",
     "typescript": "^5.7.0"


### PR DESCRIPTION
## 概要 / Why
ESLint なしで運用してきたが、コードが増える前に高速 lint を入れる。CLAUDE.md / tech-stack.md で **oxlint 採用確定**。Rust 実装でネイティブ並列、35 files で 37ms（ESLint と桁違い）。

## 変更内容 / What

### `.oxlintrc.json`（root 1 個）
- `plugins`: `typescript` / `oxc` / `import` / `promise` / `node` / `unicorn`
- `categories`:
  - `correctness`, `suspicious`, `perf` を `error`
  - `restriction`, `pedantic`, `style`, `nursery` は `off`（過剰指摘を避ける、必要なら個別 rule で有効化）
- `rules`: 既存コードに合わせた微調整
  - `no-console`: `off`（CLI は console 出力前提）
  - `unicorn/no-process-exit`: `off`（CLI で正当に使う）
  - `import/no-cycle`: `warn`
  - `unicorn/prefer-node-protocol`: `warn`
- `overrides`:
  - test 系（`__tests__/**`, `*.test.ts`, `*.spec.ts`）の `no-empty` を緩和
  - `packages/db/drizzle.config.ts` の `import/no-default-export` を緩和（drizzle-kit が default export を要求）
- `ignorePatterns`: `node_modules` / `dist` / `.turbo` / `packages/db/drizzle/**`（生成 SQL）/ supabase 一時 dir

### `package.json`
- devDep に `oxlint@^1.62.0`
- scripts:
  - `lint`: `oxlint` （root から全体スキャン）
  - `lint:fix`: `oxlint --fix`
  - 旧 `bun run --filter '*' lint` は廃止

### `.github/workflows/ci.yml`
- 新規 `Lint` job 追加。`bunx oxlint --format=github` で **inline annotation** が PR diff に乗る

### `lefthook.yml`
- `pre-commit` に oxlint を追加
  - `glob: "*.{ts,tsx,js,jsx,mjs,cjs}"`
  - staged file のみに対して実行
  - `parallel: true`

## 設計判断
- **monorepo は root 1 個 config**（oxlint は root から再帰スキャンする思想、package ごとは YAGNI）
- **turbo task に lint を追加しない**: 35 files で 37ms と turbo cache の overhead より速い
- **`type-aware` ルールは無効**（今回は型チェック系を入れない、`tsc --noEmit` に任せる、必要なら別 Issue で oxlint-tsgolint を検討）
- `--format=github` で CI のレビューコメント連携

## ローカル動作確認
```
$ bun run lint
$ oxlint
Found 0 warnings and 0 errors.
Finished in 37ms on 35 files with 145 rules using 12 threads.
```

## スコープ外 / Out of scope
- `type-aware` ルール / `oxlint-tsgolint` 採用（必要になったら別 Issue）
- ESLint 併用（typed-lint 必要になったら）
- IDE 連携（VSCode 拡張は user 設定）
- 既存コードのリファクタ修正（lint 対象は今後の追加コードに焦点）

## 検証 / Test plan
- [x] `bun run lint` ローカル green
- [x] `bunx oxlint --format=github` ローカル green
- [x] lefthook pre-commit が `glob` で TS/JS のみに走るよう設定
- [ ] CI で Lint job green
- [ ] PR diff の auto-labeler で `changed/build`, `changed/ci` が付く

## 関連 Issue / Links
- Closes #49
- 元: #36 (research)
- 依存導入済み: #47 (lefthook PR #55)