### PR TITLE
feat(schema): add Zod branded types and Japanese error messages

### DIFF
--- a/apps/core/api/src/index.ts
+++ b/apps/core/api/src/index.ts
@@ -1,5 +1,8 @@
 import { createDb } from "@prep-hamster/db"
+import { installJaErrorMap } from "@prep-hamster/schema"
 import { createApp } from "./app"
+
+installJaErrorMap()
 
 const DEFAULT_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 

--- a/apps/user/client/cli/package.json
+++ b/apps/user/client/cli/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@prep-hamster/api-client": "workspace:*",
+    "@prep-hamster/schema": "workspace:*",
     "citty": "^0.1.6"
   }
 }

--- a/apps/user/client/cli/src/index.ts
+++ b/apps/user/client/cli/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 import { runMain } from "citty"
+import { installJaErrorMap } from "@prep-hamster/schema"
 import { main } from "./main"
+
+installJaErrorMap()
 
 runMain(main)

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
       },
       "dependencies": {
         "@prep-hamster/api-client": "workspace:*",
+        "@prep-hamster/schema": "workspace:*",
         "citty": "^0.1.6",
       },
     },

--- a/packages/db/src/zod-schemas.ts
+++ b/packages/db/src/zod-schemas.ts
@@ -4,8 +4,12 @@
 // - selectSchemas: 行を「読み出した形」 (timestamps・default 値が確定した形)
 // - insertSchemas: 行を「書き込む形」 (default あり col は optional)
 // - updateSchemas: 部分更新 (全 col optional)
+//
+// ID 列は branded UUID で nominal type 化する。`UserId` と `StockId` は実体は
+// string だが型では区別され、誤った id を渡すと compile error になる。
 
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from "drizzle-zod"
+import { z } from "zod"
 import {
   categories,
   groups,
@@ -22,99 +26,188 @@ import {
   users,
 } from "./schema"
 
+const brandedId = <const TName extends string>(_name: TName) => z.string().uuid().brand<TName>()
+
 // users
 export const UserSchema = createSelectSchema(users, {
+  id: () => brandedId("UserId"),
   email: (s) => s.email(),
 })
 export const UserInsertSchema = createInsertSchema(users, {
+  id: () => brandedId("UserId"),
   email: (s) => s.email(),
 })
 export const UserUpdateSchema = createUpdateSchema(users, {
+  id: () => brandedId("UserId"),
   email: (s) => s.email(),
 })
 export type User = typeof users.$inferSelect
 export type UserInsert = typeof users.$inferInsert
 
 // groups
-export const GroupSchema = createSelectSchema(groups)
-export const GroupInsertSchema = createInsertSchema(groups)
-export const GroupUpdateSchema = createUpdateSchema(groups)
+const groupBrands = {
+  id: () => brandedId("GroupId"),
+  createdBy: () => brandedId("UserId"),
+}
+export const GroupSchema = createSelectSchema(groups, groupBrands)
+export const GroupInsertSchema = createInsertSchema(groups, groupBrands)
+export const GroupUpdateSchema = createUpdateSchema(groups, groupBrands)
 export type Group = typeof groups.$inferSelect
 export type GroupInsert = typeof groups.$inferInsert
 
 // memberships
-export const MembershipSchema = createSelectSchema(memberships)
-export const MembershipInsertSchema = createInsertSchema(memberships)
-export const MembershipUpdateSchema = createUpdateSchema(memberships)
+const membershipBrands = {
+  id: () => brandedId("MembershipId"),
+  userId: () => brandedId("UserId"),
+  groupId: () => brandedId("GroupId"),
+}
+export const MembershipSchema = createSelectSchema(memberships, membershipBrands)
+export const MembershipInsertSchema = createInsertSchema(memberships, membershipBrands)
+export const MembershipUpdateSchema = createUpdateSchema(memberships, membershipBrands)
 export type Membership = typeof memberships.$inferSelect
 export type MembershipInsert = typeof memberships.$inferInsert
 
 // invitations
-export const InvitationSchema = createSelectSchema(invitations)
-export const InvitationInsertSchema = createInsertSchema(invitations)
-export const InvitationUpdateSchema = createUpdateSchema(invitations)
+const invitationBrands = {
+  id: () => brandedId("InvitationId"),
+  groupId: () => brandedId("GroupId"),
+  inviterId: () => brandedId("UserId"),
+  usedBy: () => brandedId("UserId").nullable(),
+}
+export const InvitationSchema = createSelectSchema(invitations, invitationBrands)
+export const InvitationInsertSchema = createInsertSchema(invitations, invitationBrands)
+export const InvitationUpdateSchema = createUpdateSchema(invitations, invitationBrands)
 export type Invitation = typeof invitations.$inferSelect
 export type InvitationInsert = typeof invitations.$inferInsert
 
 // locations
-export const LocationSchema = createSelectSchema(locations)
-export const LocationInsertSchema = createInsertSchema(locations)
-export const LocationUpdateSchema = createUpdateSchema(locations)
+const locationBrands = {
+  id: () => brandedId("LocationId"),
+  groupId: () => brandedId("GroupId"),
+}
+export const LocationSchema = createSelectSchema(locations, locationBrands)
+export const LocationInsertSchema = createInsertSchema(locations, locationBrands)
+export const LocationUpdateSchema = createUpdateSchema(locations, locationBrands)
 export type Location = typeof locations.$inferSelect
 export type LocationInsert = typeof locations.$inferInsert
 
 // categories
-export const CategorySchema = createSelectSchema(categories)
-export const CategoryInsertSchema = createInsertSchema(categories)
-export const CategoryUpdateSchema = createUpdateSchema(categories)
+const categoryBrands = {
+  id: () => brandedId("CategoryId"),
+  groupId: () => brandedId("GroupId"),
+}
+export const CategorySchema = createSelectSchema(categories, categoryBrands)
+export const CategoryInsertSchema = createInsertSchema(categories, categoryBrands)
+export const CategoryUpdateSchema = createUpdateSchema(categories, categoryBrands)
 export type Category = typeof categories.$inferSelect
 export type CategoryInsert = typeof categories.$inferInsert
 
 // productMasters
-export const ProductMasterSchema = createSelectSchema(productMasters)
-export const ProductMasterInsertSchema = createInsertSchema(productMasters)
-export const ProductMasterUpdateSchema = createUpdateSchema(productMasters)
+const productMasterBrands = {
+  id: () => brandedId("ProductMasterId"),
+}
+export const ProductMasterSchema = createSelectSchema(productMasters, productMasterBrands)
+export const ProductMasterInsertSchema = createInsertSchema(productMasters, productMasterBrands)
+export const ProductMasterUpdateSchema = createUpdateSchema(productMasters, productMasterBrands)
 export type ProductMaster = typeof productMasters.$inferSelect
 export type ProductMasterInsert = typeof productMasters.$inferInsert
 
 // items
-export const ItemSchema = createSelectSchema(items)
-export const ItemInsertSchema = createInsertSchema(items)
-export const ItemUpdateSchema = createUpdateSchema(items)
+const itemBrands = {
+  id: () => brandedId("ItemId"),
+  groupId: () => brandedId("GroupId"),
+  productMasterId: () => brandedId("ProductMasterId").nullable(),
+  categoryId: () => brandedId("CategoryId").nullable(),
+}
+export const ItemSchema = createSelectSchema(items, itemBrands)
+export const ItemInsertSchema = createInsertSchema(items, itemBrands)
+export const ItemUpdateSchema = createUpdateSchema(items, itemBrands)
 export type Item = typeof items.$inferSelect
 export type ItemInsert = typeof items.$inferInsert
 
 // stocks
-export const StockSchema = createSelectSchema(stocks)
-export const StockInsertSchema = createInsertSchema(stocks)
-export const StockUpdateSchema = createUpdateSchema(stocks)
+const stockBrands = {
+  id: () => brandedId("StockId"),
+  groupId: () => brandedId("GroupId"),
+  itemId: () => brandedId("ItemId"),
+  locationId: () => brandedId("LocationId"),
+}
+export const StockSchema = createSelectSchema(stocks, stockBrands)
+export const StockInsertSchema = createInsertSchema(stocks, stockBrands)
+export const StockUpdateSchema = createUpdateSchema(stocks, stockBrands)
 export type Stock = typeof stocks.$inferSelect
 export type StockInsert = typeof stocks.$inferInsert
 
 // stockEvents
-export const StockEventSchema = createSelectSchema(stockEvents)
-export const StockEventInsertSchema = createInsertSchema(stockEvents)
-export const StockEventUpdateSchema = createUpdateSchema(stockEvents)
+const stockEventBrands = {
+  id: () => brandedId("StockEventId"),
+  groupId: () => brandedId("GroupId"),
+  stockId: () => brandedId("StockId"),
+  fromLocationId: () => brandedId("LocationId").nullable(),
+  toLocationId: () => brandedId("LocationId").nullable(),
+  actorUserId: () => brandedId("UserId").nullable(),
+}
+export const StockEventSchema = createSelectSchema(stockEvents, stockEventBrands)
+export const StockEventInsertSchema = createInsertSchema(stockEvents, stockEventBrands)
+export const StockEventUpdateSchema = createUpdateSchema(stockEvents, stockEventBrands)
 export type StockEvent = typeof stockEvents.$inferSelect
 export type StockEventInsert = typeof stockEvents.$inferInsert
 
 // requirementSettings
-export const RequirementSettingSchema = createSelectSchema(requirementSettings)
-export const RequirementSettingInsertSchema = createInsertSchema(requirementSettings)
-export const RequirementSettingUpdateSchema = createUpdateSchema(requirementSettings)
+const requirementSettingBrands = {
+  id: () => brandedId("RequirementSettingId"),
+  groupId: () => brandedId("GroupId"),
+}
+export const RequirementSettingSchema = createSelectSchema(
+  requirementSettings,
+  requirementSettingBrands,
+)
+export const RequirementSettingInsertSchema = createInsertSchema(
+  requirementSettings,
+  requirementSettingBrands,
+)
+export const RequirementSettingUpdateSchema = createUpdateSchema(
+  requirementSettings,
+  requirementSettingBrands,
+)
 export type RequirementSetting = typeof requirementSettings.$inferSelect
 export type RequirementSettingInsert = typeof requirementSettings.$inferInsert
 
 // shoppingListItems
-export const ShoppingListItemSchema = createSelectSchema(shoppingListItems)
-export const ShoppingListItemInsertSchema = createInsertSchema(shoppingListItems)
-export const ShoppingListItemUpdateSchema = createUpdateSchema(shoppingListItems)
+const shoppingListItemBrands = {
+  id: () => brandedId("ShoppingListItemId"),
+  groupId: () => brandedId("GroupId"),
+  itemId: () => brandedId("ItemId").nullable(),
+  addedBy: () => brandedId("UserId"),
+}
+export const ShoppingListItemSchema = createSelectSchema(shoppingListItems, shoppingListItemBrands)
+export const ShoppingListItemInsertSchema = createInsertSchema(
+  shoppingListItems,
+  shoppingListItemBrands,
+)
+export const ShoppingListItemUpdateSchema = createUpdateSchema(
+  shoppingListItems,
+  shoppingListItemBrands,
+)
 export type ShoppingListItem = typeof shoppingListItems.$inferSelect
 export type ShoppingListItemInsert = typeof shoppingListItems.$inferInsert
 
 // notificationSettings
-export const NotificationSettingSchema = createSelectSchema(notificationSettings)
-export const NotificationSettingInsertSchema = createInsertSchema(notificationSettings)
-export const NotificationSettingUpdateSchema = createUpdateSchema(notificationSettings)
+const notificationSettingBrands = {
+  id: () => brandedId("NotificationSettingId"),
+  userId: () => brandedId("UserId"),
+}
+export const NotificationSettingSchema = createSelectSchema(
+  notificationSettings,
+  notificationSettingBrands,
+)
+export const NotificationSettingInsertSchema = createInsertSchema(
+  notificationSettings,
+  notificationSettingBrands,
+)
+export const NotificationSettingUpdateSchema = createUpdateSchema(
+  notificationSettings,
+  notificationSettingBrands,
+)
 export type NotificationSetting = typeof notificationSettings.$inferSelect
 export type NotificationSettingInsert = typeof notificationSettings.$inferInsert

--- a/packages/db/src/zod-schemas.ts
+++ b/packages/db/src/zod-schemas.ts
@@ -7,9 +7,13 @@
 //
 // ID 列は branded UUID で nominal type 化する。`UserId` と `StockId` は実体は
 // string だが型では区別され、誤った id を渡すと compile error になる。
+//
+// refinement callback は **必ず引数 `s` を chain する**こと。`() => z.string()...`
+// のように新しい schema を返すと、drizzle-zod は列の optional / default /
+// nullable 属性を再適用しなくなる (CodeRabbit PR #65 で指摘)。
 
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from "drizzle-zod"
-import { z } from "zod"
+import type { z } from "zod"
 import {
   categories,
   groups,
@@ -26,19 +30,24 @@ import {
   users,
 } from "./schema"
 
-const brandedId = <const TName extends string>(_name: TName) => z.string().uuid().brand<TName>()
+// uuid 列を branded uuid に置換するヘルパ。`s` を chain することで
+// drizzle-zod が列属性 (optional / nullable) を outer 側で再適用する性質を保つ。
+const brandUuid =
+  <const TName extends string>(_name: TName) =>
+  (s: z.ZodString) =>
+    s.uuid().brand<TName>()
 
 // users
 export const UserSchema = createSelectSchema(users, {
-  id: () => brandedId("UserId"),
+  id: brandUuid("UserId"),
   email: (s) => s.email(),
 })
 export const UserInsertSchema = createInsertSchema(users, {
-  id: () => brandedId("UserId"),
+  id: brandUuid("UserId"),
   email: (s) => s.email(),
 })
 export const UserUpdateSchema = createUpdateSchema(users, {
-  id: () => brandedId("UserId"),
+  id: brandUuid("UserId"),
   email: (s) => s.email(),
 })
 export type User = typeof users.$inferSelect
@@ -46,8 +55,8 @@ export type UserInsert = typeof users.$inferInsert
 
 // groups
 const groupBrands = {
-  id: () => brandedId("GroupId"),
-  createdBy: () => brandedId("UserId"),
+  id: brandUuid("GroupId"),
+  createdBy: brandUuid("UserId"),
 }
 export const GroupSchema = createSelectSchema(groups, groupBrands)
 export const GroupInsertSchema = createInsertSchema(groups, groupBrands)
@@ -57,9 +66,9 @@ export type GroupInsert = typeof groups.$inferInsert
 
 // memberships
 const membershipBrands = {
-  id: () => brandedId("MembershipId"),
-  userId: () => brandedId("UserId"),
-  groupId: () => brandedId("GroupId"),
+  id: brandUuid("MembershipId"),
+  userId: brandUuid("UserId"),
+  groupId: brandUuid("GroupId"),
 }
 export const MembershipSchema = createSelectSchema(memberships, membershipBrands)
 export const MembershipInsertSchema = createInsertSchema(memberships, membershipBrands)
@@ -69,10 +78,10 @@ export type MembershipInsert = typeof memberships.$inferInsert
 
 // invitations
 const invitationBrands = {
-  id: () => brandedId("InvitationId"),
-  groupId: () => brandedId("GroupId"),
-  inviterId: () => brandedId("UserId"),
-  usedBy: () => brandedId("UserId").nullable(),
+  id: brandUuid("InvitationId"),
+  groupId: brandUuid("GroupId"),
+  inviterId: brandUuid("UserId"),
+  usedBy: brandUuid("UserId"),
 }
 export const InvitationSchema = createSelectSchema(invitations, invitationBrands)
 export const InvitationInsertSchema = createInsertSchema(invitations, invitationBrands)
@@ -82,8 +91,8 @@ export type InvitationInsert = typeof invitations.$inferInsert
 
 // locations
 const locationBrands = {
-  id: () => brandedId("LocationId"),
-  groupId: () => brandedId("GroupId"),
+  id: brandUuid("LocationId"),
+  groupId: brandUuid("GroupId"),
 }
 export const LocationSchema = createSelectSchema(locations, locationBrands)
 export const LocationInsertSchema = createInsertSchema(locations, locationBrands)
@@ -93,8 +102,8 @@ export type LocationInsert = typeof locations.$inferInsert
 
 // categories
 const categoryBrands = {
-  id: () => brandedId("CategoryId"),
-  groupId: () => brandedId("GroupId"),
+  id: brandUuid("CategoryId"),
+  groupId: brandUuid("GroupId"),
 }
 export const CategorySchema = createSelectSchema(categories, categoryBrands)
 export const CategoryInsertSchema = createInsertSchema(categories, categoryBrands)
@@ -104,7 +113,7 @@ export type CategoryInsert = typeof categories.$inferInsert
 
 // productMasters
 const productMasterBrands = {
-  id: () => brandedId("ProductMasterId"),
+  id: brandUuid("ProductMasterId"),
 }
 export const ProductMasterSchema = createSelectSchema(productMasters, productMasterBrands)
 export const ProductMasterInsertSchema = createInsertSchema(productMasters, productMasterBrands)
@@ -114,10 +123,10 @@ export type ProductMasterInsert = typeof productMasters.$inferInsert
 
 // items
 const itemBrands = {
-  id: () => brandedId("ItemId"),
-  groupId: () => brandedId("GroupId"),
-  productMasterId: () => brandedId("ProductMasterId").nullable(),
-  categoryId: () => brandedId("CategoryId").nullable(),
+  id: brandUuid("ItemId"),
+  groupId: brandUuid("GroupId"),
+  productMasterId: brandUuid("ProductMasterId"),
+  categoryId: brandUuid("CategoryId"),
 }
 export const ItemSchema = createSelectSchema(items, itemBrands)
 export const ItemInsertSchema = createInsertSchema(items, itemBrands)
@@ -127,10 +136,10 @@ export type ItemInsert = typeof items.$inferInsert
 
 // stocks
 const stockBrands = {
-  id: () => brandedId("StockId"),
-  groupId: () => brandedId("GroupId"),
-  itemId: () => brandedId("ItemId"),
-  locationId: () => brandedId("LocationId"),
+  id: brandUuid("StockId"),
+  groupId: brandUuid("GroupId"),
+  itemId: brandUuid("ItemId"),
+  locationId: brandUuid("LocationId"),
 }
 export const StockSchema = createSelectSchema(stocks, stockBrands)
 export const StockInsertSchema = createInsertSchema(stocks, stockBrands)
@@ -140,12 +149,12 @@ export type StockInsert = typeof stocks.$inferInsert
 
 // stockEvents
 const stockEventBrands = {
-  id: () => brandedId("StockEventId"),
-  groupId: () => brandedId("GroupId"),
-  stockId: () => brandedId("StockId"),
-  fromLocationId: () => brandedId("LocationId").nullable(),
-  toLocationId: () => brandedId("LocationId").nullable(),
-  actorUserId: () => brandedId("UserId").nullable(),
+  id: brandUuid("StockEventId"),
+  groupId: brandUuid("GroupId"),
+  stockId: brandUuid("StockId"),
+  fromLocationId: brandUuid("LocationId"),
+  toLocationId: brandUuid("LocationId"),
+  actorUserId: brandUuid("UserId"),
 }
 export const StockEventSchema = createSelectSchema(stockEvents, stockEventBrands)
 export const StockEventInsertSchema = createInsertSchema(stockEvents, stockEventBrands)
@@ -155,8 +164,8 @@ export type StockEventInsert = typeof stockEvents.$inferInsert
 
 // requirementSettings
 const requirementSettingBrands = {
-  id: () => brandedId("RequirementSettingId"),
-  groupId: () => brandedId("GroupId"),
+  id: brandUuid("RequirementSettingId"),
+  groupId: brandUuid("GroupId"),
 }
 export const RequirementSettingSchema = createSelectSchema(
   requirementSettings,
@@ -175,10 +184,10 @@ export type RequirementSettingInsert = typeof requirementSettings.$inferInsert
 
 // shoppingListItems
 const shoppingListItemBrands = {
-  id: () => brandedId("ShoppingListItemId"),
-  groupId: () => brandedId("GroupId"),
-  itemId: () => brandedId("ItemId").nullable(),
-  addedBy: () => brandedId("UserId"),
+  id: brandUuid("ShoppingListItemId"),
+  groupId: brandUuid("GroupId"),
+  itemId: brandUuid("ItemId"),
+  addedBy: brandUuid("UserId"),
 }
 export const ShoppingListItemSchema = createSelectSchema(shoppingListItems, shoppingListItemBrands)
 export const ShoppingListItemInsertSchema = createInsertSchema(
@@ -194,8 +203,8 @@ export type ShoppingListItemInsert = typeof shoppingListItems.$inferInsert
 
 // notificationSettings
 const notificationSettingBrands = {
-  id: () => brandedId("NotificationSettingId"),
-  userId: () => brandedId("UserId"),
+  id: brandUuid("NotificationSettingId"),
+  userId: brandUuid("UserId"),
 }
 export const NotificationSettingSchema = createSelectSchema(
   notificationSettings,

--- a/packages/schema/src/__tests__/branded.test.ts
+++ b/packages/schema/src/__tests__/branded.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test"
+import { GroupId, StockId, UserId } from "../common"
+
+const UUID = "00000000-0000-0000-0000-000000000001"
+
+test("UserId / GroupId / StockId は valid UUID を受け入れる", () => {
+  expect(UserId.safeParse(UUID).success).toBe(true)
+  expect(GroupId.safeParse(UUID).success).toBe(true)
+  expect(StockId.safeParse(UUID).success).toBe(true)
+})
+
+test("branded id は invalid UUID を拒否する", () => {
+  expect(UserId.safeParse("not-uuid").success).toBe(false)
+})
+
+test("branded type は実体としては string", () => {
+  const userId: string = UserId.parse(UUID)
+  // 実体の文字列としては UUID と一致するが、型レベルでは別物 (compile time check)
+  expect(typeof userId).toBe("string")
+  expect(userId).toBe(UUID)
+})

--- a/packages/schema/src/__tests__/error-map.test.ts
+++ b/packages/schema/src/__tests__/error-map.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test"
+import { z } from "zod"
+import { jaErrorMap } from "../error-map"
+
+// `z.setErrorMap` を直接呼ぶと global state を汚すので、
+// schema 1 個ずつに対して errorMap を渡して局所的に検証する。
+
+test("invalid_string (uuid) → 日本語メッセージ", () => {
+  const r = z.string().uuid().safeParse("not-a-uuid", { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("UUID 形式で指定してください")
+  }
+})
+
+test("invalid_string (email) → 日本語メッセージ", () => {
+  const r = z.string().email().safeParse("not-email", { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("メールアドレス形式で指定してください")
+  }
+})
+
+test("invalid_type (undefined) → 必須項目です", () => {
+  const r = z.object({ name: z.string() }).safeParse({}, { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("必須項目です")
+  }
+})
+
+test("too_small (string min 1) → 必須項目です", () => {
+  const r = z.string().min(1).safeParse("", { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("必須項目です")
+  }
+})
+
+test("too_small (number) → ◯◯ 以上の数値で指定してください", () => {
+  const r = z.number().min(10).safeParse(5, { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("10 以上の数値で指定してください")
+  }
+})
+
+test("invalid_enum_value → 候補リストを表示", () => {
+  const r = z.enum(["A", "B", "C"]).safeParse("D", { errorMap: jaErrorMap })
+  expect(r.success).toBe(false)
+  if (!r.success) {
+    expect(r.error.issues[0]?.message).toBe("次のいずれかを指定してください: A / B / C")
+  }
+})

--- a/packages/schema/src/common.ts
+++ b/packages/schema/src/common.ts
@@ -3,6 +3,52 @@ import { z } from "zod"
 // API I/F の共通プリミティブ。row schema (drizzle-zod 生成) では型が DB ネイティブ
 // (Date など) で来るため、HTTP I/O と区別するためにここに集約する。
 
+// Branded UUID 型ファクトリ。`UserId` と `StockId` は実体としては string でも
+// 型レベルで区別したいので nominal type を作る。consumer 側では `Brand<...>`
+// で受け渡しするだけで他の id を渡そうとすると compile error になる。
+export const brandedId = <const TName extends string>(_name: TName) =>
+  z.string().uuid().brand<TName>()
+
+export const UserId = brandedId("UserId")
+export type UserId = z.infer<typeof UserId>
+
+export const GroupId = brandedId("GroupId")
+export type GroupId = z.infer<typeof GroupId>
+
+export const MembershipId = brandedId("MembershipId")
+export type MembershipId = z.infer<typeof MembershipId>
+
+export const InvitationId = brandedId("InvitationId")
+export type InvitationId = z.infer<typeof InvitationId>
+
+export const LocationId = brandedId("LocationId")
+export type LocationId = z.infer<typeof LocationId>
+
+export const CategoryId = brandedId("CategoryId")
+export type CategoryId = z.infer<typeof CategoryId>
+
+export const ProductMasterId = brandedId("ProductMasterId")
+export type ProductMasterId = z.infer<typeof ProductMasterId>
+
+export const ItemId = brandedId("ItemId")
+export type ItemId = z.infer<typeof ItemId>
+
+export const StockId = brandedId("StockId")
+export type StockId = z.infer<typeof StockId>
+
+export const StockEventId = brandedId("StockEventId")
+export type StockEventId = z.infer<typeof StockEventId>
+
+export const RequirementSettingId = brandedId("RequirementSettingId")
+export type RequirementSettingId = z.infer<typeof RequirementSettingId>
+
+export const ShoppingListItemId = brandedId("ShoppingListItemId")
+export type ShoppingListItemId = z.infer<typeof ShoppingListItemId>
+
+export const NotificationSettingId = brandedId("NotificationSettingId")
+export type NotificationSettingId = z.infer<typeof NotificationSettingId>
+
+// 旧称 `Id` (汎用 UUID) は新規コードでは使わない。互換のため当面残す。
 export const Id = z.string().uuid()
 export type Id = z.infer<typeof Id>
 

--- a/packages/schema/src/error-map.ts
+++ b/packages/schema/src/error-map.ts
@@ -1,0 +1,114 @@
+import { z } from "zod"
+
+// Zod の組み込みエラーメッセージを日本語化する error map。
+// API レスポンス / CLI 出力の両方で使えるよう zod-i18n-map ではなく自前で定義し、
+// i18next 依存を持ち込まない。
+//
+// 適用は `z.setErrorMap(jaErrorMap)` を起動時 1 回呼ぶ (apps/core/api/src/index.ts
+// と CLI の entry point)。テスト中は副作用を避けたいので明示的に呼ばない。
+
+export const jaErrorMap: z.ZodErrorMap = (issue, ctx) => {
+  switch (issue.code) {
+    case z.ZodIssueCode.invalid_type:
+      if (issue.received === "undefined") {
+        return { message: "必須項目です" }
+      }
+      return {
+        message: `${typeLabel(issue.expected)}を指定してください (受信: ${typeLabel(issue.received)})`,
+      }
+
+    case z.ZodIssueCode.invalid_string:
+      if (issue.validation === "uuid") {
+        return { message: "UUID 形式で指定してください" }
+      }
+      if (issue.validation === "email") {
+        return { message: "メールアドレス形式で指定してください" }
+      }
+      if (issue.validation === "url") {
+        return { message: "URL 形式で指定してください" }
+      }
+      if (issue.validation === "datetime") {
+        return { message: "ISO 8601 形式の日時で指定してください" }
+      }
+      if (issue.validation === "date") {
+        return { message: "YYYY-MM-DD 形式の日付で指定してください" }
+      }
+      return { message: "文字列形式が不正です" }
+
+    case z.ZodIssueCode.too_small:
+      if (issue.type === "string") {
+        return {
+          message:
+            issue.minimum === 1 ? "必須項目です" : `${issue.minimum} 文字以上で指定してください`,
+        }
+      }
+      if (issue.type === "number") {
+        return {
+          message: `${issue.minimum} 以上の数値で指定してください`,
+        }
+      }
+      if (issue.type === "array") {
+        return {
+          message: `${issue.minimum} 件以上で指定してください`,
+        }
+      }
+      break
+
+    case z.ZodIssueCode.too_big:
+      if (issue.type === "string") {
+        return { message: `${issue.maximum} 文字以下で指定してください` }
+      }
+      if (issue.type === "number") {
+        return { message: `${issue.maximum} 以下の数値で指定してください` }
+      }
+      if (issue.type === "array") {
+        return { message: `${issue.maximum} 件以下で指定してください` }
+      }
+      break
+
+    case z.ZodIssueCode.invalid_enum_value:
+      return {
+        message: `次のいずれかを指定してください: ${issue.options.join(" / ")}`,
+      }
+
+    case z.ZodIssueCode.invalid_union:
+      return { message: "いずれかの形式に一致する必要があります" }
+
+    case z.ZodIssueCode.unrecognized_keys:
+      return { message: `未知のキーが含まれています: ${issue.keys.join(", ")}` }
+
+    case z.ZodIssueCode.custom:
+      return { message: issue.message ?? "値が不正です" }
+  }
+  return { message: ctx.defaultError }
+}
+
+const typeLabel = (t: string): string => {
+  switch (t) {
+    case "string":
+      return "文字列"
+    case "number":
+      return "数値"
+    case "bigint":
+      return "整数"
+    case "boolean":
+      return "真偽値"
+    case "array":
+      return "配列"
+    case "object":
+      return "オブジェクト"
+    case "null":
+      return "null"
+    case "undefined":
+      return "undefined"
+    case "date":
+      return "日付"
+    default:
+      return t
+  }
+}
+
+// 起動時 1 回呼ぶ。テスト等で global state を汚したくない場合は呼ばない。
+export const installJaErrorMap = () => {
+  z.setErrorMap(jaErrorMap)
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -32,3 +32,4 @@ export {
 } from "@prep-hamster/db/zod"
 
 export * from "./common"
+export * from "./error-map"


### PR DESCRIPTION
## 概要 / Why

ID 系型 (`UserId` / `GroupId` / `StockId` / 等) が単なる string で、`StockId` のつもりで誤って `LocationId` を渡しても気付けない。**branded types で nominal type 化**して compile error にする。

加えて、エンドユーザーに見せるバリデーションエラー (Hono の zValidator → CLI の citty) を日本語化する error map を導入。

## 変更内容 / What

### `packages/schema`

- **`src/common.ts`**: branded UUID ファクトリ `brandedId<T>` と全 13 テーブル分の branded ID 型を定義
  - `UserId` / `GroupId` / `MembershipId` / `InvitationId` / `LocationId` / `CategoryId` / `ProductMasterId` / `ItemId` / `StockId` / `StockEventId` / `RequirementSettingId` / `ShoppingListItemId` / `NotificationSettingId`
  - 旧 `Id` (汎用 UUID) は当面互換のため残す
- **`src/error-map.ts` (新規)**: Zod の組み込み `ZodIssueCode` を日本語に翻訳する `jaErrorMap` と `installJaErrorMap()`
  - 例: `"UUID 形式で指定してください"` / `"必須項目です"` / `"次のいずれかを指定してください: A / B / C"`
  - `zod-i18n-map` ではなく自前定義（i18next 依存を持ち込まない）

### `packages/db/src/zod-schemas.ts`

drizzle-zod の refinement (`createSelectSchema(table, { col: () => schema })`) で各テーブルの ID 列を branded に置換:

```ts
// stocks
const stockBrands = {
  id: () => brandedId("StockId"),
  groupId: () => brandedId("GroupId"),
  itemId: () => brandedId("ItemId"),
  locationId: () => brandedId("LocationId"),
}
export const StockSchema = createSelectSchema(stocks, stockBrands)
```

13 テーブル × 3 (Select / Insert / Update) すべてで branded refinement を適用。既存の `email` refinement は維持。

### `apps/core/api/src/index.ts` / `apps/user/client/cli/src/index.ts`

起動時に `installJaErrorMap()` を呼んで global error map を設定。

## 設計判断

- **branded helper を `packages/db` 内で再定義**: 直接 `packages/schema` から import すると循環依存になるため。同じ実装を 2 箇所に持つが、追加コストは小さい
- **`installJaErrorMap()` は起動時 1 回呼ぶ方針**: テスト中は呼ばない（global state を汚さない）。テストは `safeParse(value, { errorMap: jaErrorMap })` で局所的に検証
- **`zod-i18n-map` を使わない**: i18next 依存を持ち込まないため自前定義。本リポは日本語のみで多言語化要件は無い
- **branded は drizzle-zod の refinement で適用**: drizzle 行データを branded にすることで、DB から取り出した瞬間に型が確定する。手動で `as UserId` するキャストは不要
- **runtime 互換性**: brand は phantom type なので `JSON.stringify` / DB I/O / HTTP I/O では string と区別不能。E2E 6/6 が通ることで確認

## スコープ外 / Out of scope

- API error response の標準化（#40 で対応）
- フロントエンド (Web / Mobile) 側のメッセージ統一
- zod v3 → v4 移行
- `BrandedTimestamp` / `BrandedDateOnly`（Issue で言及されているが ID ほど誤用しやすくないため後回し）
- 旧 `Id` の削除 (互換のため残置、別 PR でクリーンアップ)

## 検証 / Test plan

- [x] `bun run typecheck` 6/6 green
- [x] `bun run test` 9/9 green
  - schema: 7 (既存 smoke) + 6 (errorMap) + 3 (branded) = **13 件**
- [x] `bun run test:e2e` 6/6 green (実 Postgres、branded refinement のランタイム互換性確認)
- [x] `bun run lint` clean / `bunx oxfmt --check .` clean
- [ ] CI green

## 関連 Issue / Links

- Closes #51
- Refs #41 (research)
- 後続: #53 (Hono OpenAPI) — branded types を OpenAPI スキーマに乗せる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * バリデーションエラーメッセージが日本語で表示されるようになりました

* **テスト**
  * ブランド付きID スキーマのテストを追加しました
  * 日本語エラーメッセージの動作検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->