### PR TITLE
feat(api): adopt @hono/zod-openapi + middleware split + error standardization

### DIFF
--- a/apps/core/api/package.json
+++ b/apps/core/api/package.json
@@ -26,9 +26,11 @@
     "test:e2e": "bun test e2e"
   },
   "dependencies": {
+    "@hono/zod-openapi": "^0.19.10",
     "@hono/zod-validator": "^0.4.0",
     "@prep-hamster/db": "workspace:*",
     "@prep-hamster/schema": "workspace:*",
+    "@scalar/hono-api-reference": "^0.10.13",
     "drizzle-orm": "^0.41.0",
     "hono": "^4.6.0",
     "zod": "^3.24.0"

--- a/apps/core/api/src/__tests__/smoke.test.ts
+++ b/apps/core/api/src/__tests__/smoke.test.ts
@@ -34,3 +34,20 @@ test("GET /v1/stocks with invalid groupId returns 400", async () => {
   })
   expect(res.status).toBe(400)
 })
+
+test("GET /openapi.json returns OpenAPI 3.1 spec", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request("/openapi.json")
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { openapi: string; info: { title: string }; paths: object }
+  expect(body.openapi).toBe("3.1.0")
+  expect(body.info.title).toBe("prep-hamster API")
+  expect(body.paths).toHaveProperty("/v1/stocks")
+})
+
+test("GET /docs serves Scalar UI HTML", async () => {
+  const app = createApp({ db: mockDb })
+  const res = await app.request("/docs")
+  expect(res.status).toBe(200)
+  expect(res.headers.get("content-type")).toContain("text/html")
+})

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -1,5 +1,9 @@
-import { Hono } from "hono"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { Scalar } from "@scalar/hono-api-reference"
 import type { Db } from "@prep-hamster/db"
+import { withUserAuth } from "./middleware/auth"
+import { withDb } from "./middleware/db"
+import { onError } from "./middleware/error"
 import { stocksRouter } from "./routes/stocks"
 
 export type AppEnv = {
@@ -10,22 +14,27 @@ export type AppEnv = {
 }
 
 export function createApp(opts: { db: Db }) {
-  return new Hono<AppEnv>()
-    .use("*", async (c, next) => {
-      c.set("db", opts.db)
-      await next()
-    })
-    .get("/health", (c) => c.json({ ok: true as const }))
-    .use("/v1/*", async (c, next) => {
-      const userId = c.req.header("x-user-id")
-      if (!userId) {
-        return c.json({ error: "x-user-id header required" }, 401)
-      }
-      c.set("userId", userId)
-      await next()
-      return
-    })
-    .route("/v1/stocks", stocksRouter)
+  const app = new OpenAPIHono<AppEnv>()
+
+  app.onError(onError)
+  app.use("*", withDb(opts.db))
+  app.use("/v1/*", withUserAuth)
+
+  app.doc("/openapi.json", {
+    openapi: "3.1.0",
+    info: {
+      title: "prep-hamster API",
+      version: "0.0.0",
+      description: "備蓄管理アプリのバックエンド API",
+    },
+    servers: [{ url: "http://localhost:3000", description: "local dev" }],
+  })
+
+  app.get("/docs", Scalar({ url: "/openapi.json", theme: "default" }))
+
+  // route 定義をチェイン化することで `hc<typeof app>` が
+  // 全 endpoint を型として認識できるようにする。
+  return app.get("/health", (c) => c.json({ ok: true as const })).route("/v1/stocks", stocksRouter)
 }
 
 export type AppType = ReturnType<typeof createApp>

--- a/apps/core/api/src/middleware/auth.ts
+++ b/apps/core/api/src/middleware/auth.ts
@@ -1,0 +1,14 @@
+import { createMiddleware } from "hono/factory"
+import { HTTPException } from "hono/http-exception"
+import type { AppEnv } from "../app"
+
+// v1.0.0 では `x-user-id` ヘッダで stub 認証する。
+// Supabase Auth (Bearer JWT) への置き換え時はこの 1 ファイルを差し替える。
+export const withUserAuth = createMiddleware<AppEnv>(async (c, next) => {
+  const userId = c.req.header("x-user-id")
+  if (!userId) {
+    throw new HTTPException(401, { message: "x-user-id header required" })
+  }
+  c.set("userId", userId)
+  await next()
+})

--- a/apps/core/api/src/middleware/db.ts
+++ b/apps/core/api/src/middleware/db.ts
@@ -1,0 +1,11 @@
+import { createMiddleware } from "hono/factory"
+import type { Db } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+
+// `c.set("db", ...)` を 1 箇所に集約。テスト/本番で同じ middleware を使い、
+// 注入する Db インスタンスだけ差し替える。
+export const withDb = (db: Db) =>
+  createMiddleware<AppEnv>(async (c, next) => {
+    c.set("db", db)
+    await next()
+  })

--- a/apps/core/api/src/middleware/error.ts
+++ b/apps/core/api/src/middleware/error.ts
@@ -1,0 +1,87 @@
+import type { Context } from "hono"
+import { HTTPException } from "hono/http-exception"
+import { ZodError } from "zod"
+
+// 全 endpoint の error response 統一フォーマット。
+//
+//   { error: { code: string; message: string; details?: unknown } }
+//
+// status code:
+//   400 - リクエスト構文不正 / クエリ・ボディが parse 不能
+//   401 - 認証情報なし / 失効
+//   403 - 認可不足 (role 不一致)
+//   404 - 対象リソース不在
+//   422 - バリデーション失敗 (ZodError)
+//   500 - 想定外
+//
+// Problem Details (RFC 7807) は v1.0.0 ではオーバーキル。
+
+export type ApiErrorBody = {
+  error: {
+    code: string
+    message: string
+    details?: unknown
+  }
+}
+
+export const onError = (err: Error, c: Context): Response => {
+  if (err instanceof HTTPException) {
+    const res = err.getResponse()
+    // HTTPException は独自に Response を持っているが、本 API では JSON 統一フォーマットに乗せる
+    if (res.headers.get("content-type")?.includes("application/json")) {
+      return res
+    }
+    const status = err.status
+    return c.json<ApiErrorBody>(
+      {
+        error: {
+          code: codeForStatus(status),
+          message: err.message,
+        },
+      },
+      status,
+    )
+  }
+
+  if (err instanceof ZodError) {
+    return c.json<ApiErrorBody>(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "リクエストの形式が不正です",
+          details: err.flatten(),
+        },
+      },
+      422,
+    )
+  }
+
+  // 想定外エラー: stack はサーバ側ログに出し、レスポンスには message のみ返す
+  console.error("[api] unhandled error:", err)
+  return c.json<ApiErrorBody>(
+    {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "サーバ内部エラーが発生しました",
+      },
+    },
+    500,
+  )
+}
+
+const codeForStatus = (status: number): string => {
+  switch (status) {
+    case 400:
+      return "BAD_REQUEST"
+    case 401:
+      return "UNAUTHORIZED"
+    case 403:
+      return "FORBIDDEN"
+    case 404:
+      return "NOT_FOUND"
+    case 422:
+      return "VALIDATION_ERROR"
+    default:
+      return "HTTP_ERROR"
+  }
+}

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from "@hono/zod-openapi"
+
+// API I/O 用 DTO スキーマ。drizzle-zod 由来の row schema は branded type を含むが、
+// HTTP I/O 層では plain string で十分なため API 専用に切り出す。
+// branded type は内部ロジック (誤った id を渡さない) で使い、境界では plain UUID。
+
+export const errorResponseSchema = z
+  .object({
+    error: z.object({
+      code: z.string().openapi({ example: "VALIDATION_ERROR" }),
+      message: z.string().openapi({ example: "リクエストの形式が不正です" }),
+      details: z.unknown().optional(),
+    }),
+  })
+  .openapi("ApiError")
+
+export const stockDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    itemId: z.string().uuid(),
+    locationId: z.string().uuid(),
+    quantity: z.number().nonnegative(),
+    unit: z.string(),
+    useByDate: z.string().date().nullable(),
+    bestBeforeDate: z.string().date().nullable(),
+    openedAt: z.string().date().nullable(),
+    note: z.string().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Stock")
+
+export const createStockBodyDtoSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    itemId: z.string().uuid(),
+    locationId: z.string().uuid(),
+    quantity: z.number().nonnegative(),
+    unit: z.string().min(1),
+    useByDate: z.string().date().nullable(),
+    bestBeforeDate: z.string().date().nullable(),
+    openedAt: z.string().date().nullable(),
+    note: z.string().nullable(),
+  })
+  .openapi("CreateStockBody")

--- a/apps/core/api/src/routes/stocks.ts
+++ b/apps/core/api/src/routes/stocks.ts
@@ -1,24 +1,94 @@
-import { Hono } from "hono"
-import { zValidator } from "@hono/zod-validator"
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { and, eq, isNull } from "drizzle-orm"
-import { z } from "zod"
 import { stocks } from "@prep-hamster/db"
-import { StockSchema } from "@prep-hamster/schema"
 import type { AppEnv } from "../app"
+import { createStockBodyDtoSchema, errorResponseSchema, stockDtoSchema } from "./schemas"
 
 const ListQuerySchema = z.object({
-  groupId: z.string().uuid(),
+  groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
 })
 
-const CreateStockBodySchema = StockSchema.omit({
-  id: true,
-  createdAt: true,
-  updatedAt: true,
-  deletedAt: true,
+// drizzle 行を API DTO 形式 (timestamp は ISO string、id は plain UUID) に変換
+const toStockDto = (row: typeof stocks.$inferSelect): z.infer<typeof stockDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  itemId: row.itemId,
+  locationId: row.locationId,
+  quantity: row.quantity,
+  unit: row.unit,
+  useByDate: row.useByDate,
+  bestBeforeDate: row.bestBeforeDate,
+  openedAt: row.openedAt,
+  note: row.note,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
 })
 
-export const stocksRouter = new Hono<AppEnv>()
-  .get("/", zValidator("query", ListQuerySchema), async (c) => {
+const listStocksRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["stocks"],
+  summary: "在庫一覧を取得",
+  request: {
+    query: ListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "在庫一覧",
+      content: {
+        "application/json": {
+          schema: z.object({ stocks: z.array(stockDtoSchema) }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "クエリ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createStockRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["stocks"],
+  summary: "在庫を 1 件作成",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: createStockBodyDtoSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const stocksRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listStocksRoute, async (c) => {
     const { groupId } = c.req.valid("query")
     const db = c.get("db")
 
@@ -27,9 +97,9 @@ export const stocksRouter = new Hono<AppEnv>()
       .from(stocks)
       .where(and(eq(stocks.groupId, groupId), isNull(stocks.deletedAt)))
 
-    return c.json({ stocks: rows })
+    return c.json({ stocks: rows.map(toStockDto) }, 200)
   })
-  .post("/", zValidator("json", CreateStockBodySchema), async (c) => {
+  .openapi(createStockRoute, async (c) => {
     const body = c.req.valid("json")
     const db = c.get("db")
 
@@ -49,5 +119,8 @@ export const stocksRouter = new Hono<AppEnv>()
       })
       .returning()
 
-    return c.json({ stock: created }, 201)
+    if (!created) {
+      throw new Error("insert returned no row")
+    }
+    return c.json({ stock: toStockDto(created) }, 201)
   })

--- a/bun.lock
+++ b/bun.lock
@@ -29,9 +29,11 @@
       "name": "@prep-hamster/api",
       "version": "0.0.0",
       "dependencies": {
+        "@hono/zod-openapi": "^0.19.10",
         "@hono/zod-validator": "^0.4.0",
         "@prep-hamster/db": "workspace:*",
         "@prep-hamster/schema": "workspace:*",
+        "@scalar/hono-api-reference": "^0.10.13",
         "drizzle-orm": "^0.41.0",
         "hono": "^4.6.0",
         "zod": "^3.24.0",
@@ -83,6 +85,8 @@
     },
   },
   "packages": {
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.4", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA=="],
+
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
@@ -134,6 +138,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
+
+    "@hono/zod-openapi": ["@hono/zod-openapi@0.19.10", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^7.3.0", "@hono/zod-validator": "^0.7.1", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": ">=3.0.0" } }, "sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
@@ -226,6 +232,14 @@
     "@prep-hamster/db": ["@prep-hamster/db@workspace:packages/db"],
 
     "@prep-hamster/schema": ["@prep-hamster/schema@workspace:packages/schema"],
+
+    "@scalar/client-side-rendering": ["@scalar/client-side-rendering@0.1.6", "", { "dependencies": { "@scalar/types": "0.9.5" } }, "sha512-ooc5RKyi83EvBuxB2N8H00ZE2CF4oKynuUToSCaoqxkjv+oJ6B3+OYsb0HVixznsyWhUDdtQZm4/xOb0kxBaaA=="],
+
+    "@scalar/helpers": ["@scalar/helpers@0.5.5", "", {}, "sha512-TqbErkqGijJJW6Ad8lpswHFTmlJaYFt9oolaWF1/Nn9171xdkK9ZDAk3pCaOCWs8WpwvcbUSxIVD8JxdBg0MFg=="],
+
+    "@scalar/hono-api-reference": ["@scalar/hono-api-reference@0.10.13", "", { "dependencies": { "@scalar/client-side-rendering": "0.1.6" }, "peerDependencies": { "hono": "^4.12.5" } }, "sha512-xYSN6GVdzsgt5i3OTt4wDpIcD/KpKTwb6Wiy65NucGIFW0WidM6ilb9Lf8EG9xescut5djLtGOOxO4Ze0w8qgQ=="],
+
+    "@scalar/types": ["@scalar/types@0.9.5", "", { "dependencies": { "@scalar/helpers": "0.5.5", "nanoid": "^5.1.6", "type-fest": "^5.3.1", "zod": "^4.3.5" } }, "sha512-joen5nuqgmGzgXK5XIqkGs0JmCZ16djaw+pgC24sfb+p3sSPVfKQTNTil/RuvHMNsmA/dFcQ6GI0Y3HhTlUQrg=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA=="],
 
@@ -327,11 +341,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
+
+    "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
 
     "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 
@@ -353,11 +371,15 @@
 
     "supabase": ["supabase@2.98.0", "", { "dependencies": { "bin-links": "^6.0.0", "https-proxy-agent": "^9.0.0", "node-fetch": "^3.3.2", "tar": "7.5.13" }, "bin": { "supabase": "bin/supabase" } }, "sha512-1r56wzoi6SFj+i0XHqF9rSLrjaBSrs+t6xUWn3I+UVnO9nb5ITkmaLEeGgjf7naiBUDf9rtqyRoI+5hTrezZNg=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -369,9 +391,15 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@hono/zod-openapi/@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
+
+    "@scalar/types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 


### PR DESCRIPTION
## 概要 / Why

- v1.0.0 で Web / Mobile クライアントとの I/F 整合性を取るため OpenAPI 3.1 spec を生成・配信する
- 現状の middleware (auth stub / db inject) が ad-hoc で `app.ts` に混在
- error response が endpoint ごとにバラバラ ({ error: "msg" } 形式が多いが ZodError は 400 で素のまま等)

## 変更内容 / What

### 1. OpenAPI ライブラリ採用

- **`@hono/zod-openapi@^0.19.10`** を選択（公式パッケージ、zod v3 系最終ライン）。`@hono/zod-openapi@^1.0` は zod v4 専用なので採用見送り
- **`@scalar/hono-api-reference`** で `/docs` に Scalar UI を提供（Swagger UI より軽量・モダン）

### 2. ルート定義を OpenAPI ベースに書き換え

- `apps/core/api/src/routes/stocks.ts`: `zValidator` → `createRoute` + `app.openapi(route, handler)` パターン
- `routes/schemas.ts` (新規): **API I/O 専用 DTO スキーマ** を集約
  - `errorResponseSchema` / `stockDtoSchema` / `createStockBodyDtoSchema`
  - 設計: drizzle-zod 由来の branded row schema は **内部用**、HTTP 境界では plain UUID + ISO string で expose する
  - drizzle 行 (`Date` / `string` 混在) を `toStockDto` で ISO 文字列に正規化

### 3. Middleware 責務分割

`apps/core/api/src/middleware/` 配下に 3 ファイル:

| ファイル | 責務 |
|---|---|
| `db.ts` | `withDb(db)` - `c.set("db", ...)` を集約 |
| `auth.ts` | `withUserAuth` - `x-user-id` stub 認証。将来 Supabase Auth (Bearer) に置き換える土台 |
| `error.ts` | `onError` グローバルハンドラ - error response を全 endpoint で統一 |

`app.ts` は middleware を組み立てるだけになり責務が明確化。

### 4. Error response 標準化

形式（Problem Details RFC 7807 ではなく自前形式 — v1.0.0 で十分）:

```json
{
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "リクエストの形式が不正です",
    "details": { ... }
  }
}
```

| Status | Code | 発生条件 |
|---|---|---|
| 400 | BAD_REQUEST | リクエスト構文不正 / クエリ・ボディが parse 不能 |
| 401 | UNAUTHORIZED | 認証情報なし / 失効 |
| 403 | FORBIDDEN | 認可不足 |
| 404 | NOT_FOUND | 対象リソース不在 |
| 422 | VALIDATION_ERROR | バリデーション失敗 (ZodError → flatten()) |
| 500 | INTERNAL_ERROR | 想定外（stack はサーバログのみ） |

### 5. typed client の継続動作

- `createApp` の return を `app.get("/health").route("/v1/stocks", stocksRouter)` のチェイン形式にし、`hc<AppType>` が `/health` と `/v1/*` を**両方**型として認識できるようにする
- `packages/api-client` には変更なし

## 設計判断

- **`@hono/zod-openapi@0.19.10` を選択**: zod v4 必須の v1.x ではなく v3 互換最終ライン。zod v4 移行は別 Issue (drizzle-zod 0.8 / hono-validator 0.5+ 等の同期が必要)
- **API DTO スキーマを drizzle-zod から分離**: branded type は内部不変条件用 (#51 で導入)、HTTP 境界では plain string で十分。`hc` クライアントの型推論コストを抑えるためにも DTO 化が有利
- **Scalar UI を採用 (Swagger UI ではなく)**: 軽量・モダン・OpenAPI 3.1 対応・JSON-only エクスポートにも対応
- **error response は自前形式**: Problem Details (RFC 7807) は v1.0.0 のスコープではオーバーキル
- **`withUserAuth` を middleware factory ではなく直接 export**: stub は引数を取らないので fn のまま。Supabase Auth 化のときに factory にする

## スコープ外 / Out of scope

- pino logger 連携（別 Issue）
- Supabase Auth Bearer 検証（別 Issue / `withUserAuth` 差し替えで対応）
- Web / Mobile 側で OpenAPI spec を消費する方法（別 Issue）
- バリデーションエラーの国際化（#51 の `installJaErrorMap` で対応済み、details の Zod issue は英語のまま）

## 検証 / Test plan

- [x] `bun run typecheck` 6/6 green
- [x] `bun run test` 9/9 green
  - `apps/core/api/src/__tests__/smoke.test.ts` に 2 件追加（`/openapi.json` 200 + 3.1 spec / `/docs` HTML）
- [x] `bun run test:e2e` 6/6 green（実 Postgres、route 書き換え後も互換動作）
- [x] `bun run lint` clean / `bunx oxfmt --check .` clean
- [x] `packages/api-client` の typed client (hc) が引き続き型解決される

## 関連 Issue / Links

- Closes #53
- Refs #40 (research)
- Refs #51 (branded types — 内部用、本 PR で API 境界では plain UUID として剥離)