### PR TITLE
feat(api): add /v1/groups CRUD with owner membership auto-creation

### DIFF
--- a/apps/core/api/e2e/groups.test.ts
+++ b/apps/core/api/e2e/groups.test.ts
@@ -1,0 +1,160 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { groups, memberships } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import { seedGroupWithMembership, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("GET /v1/groups without x-user-id returns 401", async () => {
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/groups")
+  expect(res.status).toBe(401)
+})
+
+test("POST /v1/groups creates group + OWNER membership in single tx", async () => {
+  const userId = await seedUser()
+  const app = createApp({ db: testDb })
+
+  const res = await app.request("/v1/groups", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": userId,
+    },
+    body: JSON.stringify({ name: "Sample Household" }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as {
+    group: { id: string; name: string; createdBy: string }
+    membership: { id: string; userId: string; groupId: string; role: string }
+  }
+
+  expect(body.group.name).toBe("Sample Household")
+  expect(body.group.createdBy).toBe(userId)
+  expect(body.membership.userId).toBe(userId)
+  expect(body.membership.groupId).toBe(body.group.id)
+  expect(body.membership.role).toBe("OWNER")
+
+  // tx 整合性: group も membership も DB に存在すること
+  const groupRows = await testDb.select().from(groups).where(eq(groups.id, body.group.id))
+  expect(groupRows).toHaveLength(1)
+  const membershipRows = await testDb
+    .select()
+    .from(memberships)
+    .where(eq(memberships.groupId, body.group.id))
+  expect(membershipRows).toHaveLength(1)
+  expect(membershipRows[0]?.role).toBe("OWNER")
+})
+
+test("POST /v1/groups with empty name returns 422", async () => {
+  const userId = await seedUser()
+  const app = createApp({ db: testDb })
+
+  const res = await app.request("/v1/groups", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": userId,
+    },
+    body: JSON.stringify({ name: "" }),
+  })
+
+  expect(res.status).toBe(400)
+})
+
+test("GET /v1/groups returns only groups the user is a member of", async () => {
+  const aliceId = await seedUser("Alice")
+  const bobId = await seedUser("Bob")
+  const aliceGroupId = await seedGroupWithMembership(aliceId, "Alice's Home")
+  await seedGroupWithMembership(bobId, "Bob's Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/groups", {
+    headers: { "x-user-id": aliceId },
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { groups: { id: string; name: string }[] }
+  expect(body.groups).toHaveLength(1)
+  expect(body.groups[0]?.id).toBe(aliceGroupId)
+  expect(body.groups[0]?.name).toBe("Alice's Home")
+})
+
+test("GET /v1/groups/:id by non-member returns 404", async () => {
+  const aliceId = await seedUser("Alice")
+  const bobId = await seedUser("Bob")
+  const bobGroupId = await seedGroupWithMembership(bobId, "Bob's Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${bobGroupId}`, {
+    headers: { "x-user-id": aliceId },
+  })
+
+  expect(res.status).toBe(404)
+})
+
+test("PATCH /v1/groups/:id by OWNER returns 200 and updates name", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Old Name")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": userId,
+    },
+    body: JSON.stringify({ name: "New Name" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { group: { id: string; name: string } }
+  expect(body.group.id).toBe(groupId)
+  expect(body.group.name).toBe("New Name")
+})
+
+test("PATCH /v1/groups/:id by EDITOR returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const editorId = await seedUser("Editor")
+  const groupId = await seedGroupWithMembership(ownerId, "Shared Home")
+  await seedMembership(editorId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": editorId,
+    },
+    body: JSON.stringify({ name: "Hijack Attempt" }),
+  })
+
+  expect(res.status).toBe(403)
+})
+
+test("PATCH /v1/groups/:id by non-member returns 404", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Closed Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": outsiderId,
+    },
+    body: JSON.stringify({ name: "Sneak" }),
+  })
+
+  expect(res.status).toBe(404)
+})

--- a/apps/core/api/e2e/seed.ts
+++ b/apps/core/api/e2e/seed.ts
@@ -8,6 +8,53 @@ export type SeedFixture = {
   locationId: string
 }
 
+export async function seedUser(displayName = "E2E User"): Promise<string> {
+  const userId = crypto.randomUUID()
+  await testDb.insert(users).values({
+    id: userId,
+    email: `e2e-${userId}@example.test`,
+    displayName,
+    locale: "ja-JP",
+  })
+  return userId
+}
+
+export async function seedGroupWithMembership(
+  ownerUserId: string,
+  name = "E2E Group",
+): Promise<string> {
+  const groupId = crypto.randomUUID()
+  await testDb.insert(groups).values({
+    id: groupId,
+    name,
+    createdBy: ownerUserId,
+  })
+  await testDb.insert(memberships).values({
+    id: crypto.randomUUID(),
+    userId: ownerUserId,
+    groupId,
+    role: "OWNER",
+    joinedAt: new Date(),
+  })
+  return groupId
+}
+
+export async function seedMembership(
+  userId: string,
+  groupId: string,
+  role: "OWNER" | "EDITOR" | "VIEWER",
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await testDb.insert(memberships).values({
+    id,
+    userId,
+    groupId,
+    role,
+    joinedAt: new Date(),
+  })
+  return id
+}
+
 export async function seedBaseFixture(): Promise<SeedFixture> {
   const userId = crypto.randomUUID()
   const groupId = crypto.randomUUID()

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -4,6 +4,7 @@ import type { Db } from "@prep-hamster/db"
 import { withUserAuth } from "./middleware/auth"
 import { withDb } from "./middleware/db"
 import { onError } from "./middleware/error"
+import { groupsRouter } from "./routes/groups"
 import { stocksRouter } from "./routes/stocks"
 
 export type AppEnv = {
@@ -34,7 +35,10 @@ export function createApp(opts: { db: Db }) {
 
   // route 定義をチェイン化することで `hc<typeof app>` が
   // 全 endpoint を型として認識できるようにする。
-  return app.get("/health", (c) => c.json({ ok: true as const })).route("/v1/stocks", stocksRouter)
+  return app
+    .get("/health", (c) => c.json({ ok: true as const }))
+    .route("/v1/groups", groupsRouter)
+    .route("/v1/stocks", stocksRouter)
 }
 
 export type AppType = ReturnType<typeof createApp>

--- a/apps/core/api/src/routes/groups.ts
+++ b/apps/core/api/src/routes/groups.ts
@@ -1,0 +1,311 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, eq, inArray, isNull } from "drizzle-orm"
+import { groups, memberships } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import {
+  createGroupBodyDtoSchema,
+  errorResponseSchema,
+  groupDtoSchema,
+  membershipDtoSchema,
+  updateGroupBodyDtoSchema,
+} from "./schemas"
+
+const IdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "id", in: "path" } }),
+})
+
+const toGroupDto = (row: typeof groups.$inferSelect): z.infer<typeof groupDtoSchema> => ({
+  id: row.id,
+  name: row.name,
+  createdBy: row.createdBy,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const toMembershipDto = (
+  row: typeof memberships.$inferSelect,
+): z.infer<typeof membershipDtoSchema> => ({
+  id: row.id,
+  userId: row.userId,
+  groupId: row.groupId,
+  role: row.role,
+  joinedAt: row.joinedAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const listGroupsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["groups"],
+  summary: "current user が所属する group 一覧",
+  responses: {
+    200: {
+      description: "所属 group 一覧",
+      content: {
+        "application/json": {
+          schema: z.object({ groups: z.array(groupDtoSchema) }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createGroupRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["groups"],
+  summary: "group を作成し、作成者を OWNER として membership 追加",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: createGroupBodyDtoSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": {
+          schema: z.object({
+            group: groupDtoSchema,
+            membership: membershipDtoSchema,
+          }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const getGroupRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["groups"],
+  summary: "group 単件取得（member のみ）",
+  request: { params: IdParamSchema },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: z.object({ group: groupDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "未参加 or 存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchGroupRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["groups"],
+  summary: "group の名前変更（OWNER のみ）",
+  request: {
+    params: IdParamSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: updateGroupBodyDtoSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": {
+          schema: z.object({ group: groupDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "OWNER でない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "未参加 or 存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const groupsRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listGroupsRoute, async (c) => {
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const memberRows = await db
+      .select({ groupId: memberships.groupId })
+      .from(memberships)
+      .where(and(eq(memberships.userId, userId), isNull(memberships.deletedAt)))
+
+    if (memberRows.length === 0) {
+      return c.json({ groups: [] }, 200)
+    }
+
+    const rows = await db
+      .select()
+      .from(groups)
+      .where(
+        and(
+          inArray(
+            groups.id,
+            memberRows.map((m) => m.groupId),
+          ),
+          isNull(groups.deletedAt),
+        ),
+      )
+
+    return c.json({ groups: rows.map(toGroupDto) }, 200)
+  })
+  .openapi(createGroupRoute, async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const now = new Date()
+    const result = await db.transaction(async (tx) => {
+      const [createdGroup] = await tx
+        .insert(groups)
+        .values({
+          id: crypto.randomUUID(),
+          name: body.name,
+          createdBy: userId,
+        })
+        .returning()
+      if (!createdGroup) {
+        throw new Error("group insert returned no row")
+      }
+
+      const [createdMembership] = await tx
+        .insert(memberships)
+        .values({
+          id: crypto.randomUUID(),
+          userId,
+          groupId: createdGroup.id,
+          role: "OWNER",
+          joinedAt: now,
+        })
+        .returning()
+      if (!createdMembership) {
+        throw new Error("membership insert returned no row")
+      }
+
+      return { group: createdGroup, membership: createdMembership }
+    })
+
+    return c.json(
+      {
+        group: toGroupDto(result.group),
+        membership: toMembershipDto(result.membership),
+      },
+      201,
+    )
+  })
+  .openapi(getGroupRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [member] = await db
+      .select({ id: memberships.id })
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.userId, userId),
+          eq(memberships.groupId, id),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+
+    if (!member) {
+      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
+    }
+
+    const [row] = await db
+      .select()
+      .from(groups)
+      .where(and(eq(groups.id, id), isNull(groups.deletedAt)))
+      .limit(1)
+
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
+    }
+
+    return c.json({ group: toGroupDto(row) }, 200)
+  })
+  .openapi(patchGroupRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [member] = await db
+      .select({ role: memberships.role })
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.userId, userId),
+          eq(memberships.groupId, id),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+
+    if (!member) {
+      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
+    }
+    if (member.role !== "OWNER") {
+      return c.json({ error: { code: "FORBIDDEN", message: "OWNER のみ更新できます" } }, 403)
+    }
+
+    const [row] = await db
+      .update(groups)
+      .set({ name: body.name, updatedAt: new Date() })
+      .where(and(eq(groups.id, id), isNull(groups.deletedAt)))
+      .returning()
+
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
+    }
+
+    return c.json({ group: toGroupDto(row) }, 200)
+  })

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -14,6 +14,44 @@ export const errorResponseSchema = z
   })
   .openapi("ApiError")
 
+export const roleSchema = z.enum(["OWNER", "EDITOR", "VIEWER"]).openapi("Role")
+
+export const groupDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string(),
+    createdBy: z.string().uuid(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Group")
+
+export const membershipDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    userId: z.string().uuid(),
+    groupId: z.string().uuid(),
+    role: roleSchema,
+    joinedAt: z.string().datetime({ offset: true }),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Membership")
+
+export const createGroupBodyDtoSchema = z
+  .object({
+    name: z.string().min(1).max(100),
+  })
+  .openapi("CreateGroupBody")
+
+export const updateGroupBodyDtoSchema = z
+  .object({
+    name: z.string().min(1).max(100),
+  })
+  .openapi("UpdateGroupBody")
+
 export const stockDtoSchema = z
   .object({
     id: z.string().uuid(),


### PR DESCRIPTION
## 概要 / Why

v1.0.0 の全リソース (locations / items / stocks / categories) は `groupId` で論理分離されているが、現状 `groups` 行を作る endpoint が無く、E2E テストも seed で直接 INSERT していた。

モバイル MVP（#76 / #77）の手前で必要な vertical slice の前提として、`/v1/groups` の CRUD と OWNER membership 自動作成を実装する。Issue #67 / docs/flow/v1.0.0/mobile-mvp.md 8 章のクリティカルパス先頭。

## 変更内容 / What

### 新 endpoint

| Method | Path | 認可 | 概要 |
| ------ | ---- | ---- | ---- |
| POST | `/v1/groups` | 認証のみ | group + OWNER membership を **同一 transaction** で作成 |
| GET | `/v1/groups` | 認証のみ | current user が所属する group の一覧 |
| GET | `/v1/groups/:id` | member のみ | 単件取得（非 member は 404） |
| PATCH | `/v1/groups/:id` | OWNER のみ | 名前を更新（EDITOR / VIEWER は 403） |

### スキーマ追加 (`routes/schemas.ts`)

- `roleSchema` (OWNER / EDITOR / VIEWER 列挙)
- `groupDtoSchema` / `membershipDtoSchema` (HTTP 境界用 DTO)
- `createGroupBodyDtoSchema` / `updateGroupBodyDtoSchema` (`name: min 1, max 100`)

### tx 設計

POST 時の group 作成と OWNER membership 追加は `db.transaction()` で原子化。membership 作成失敗時に group だけ残るのを防ぐ。

### 認可

#69 の group 認可 middleware 横断版は別 Issue。本 PR では各 endpoint 内で memberships を都度照会する素朴な実装。non-member は 404、member だが OWNER でない場合は 403 で区別する。

### E2E 追加 (`e2e/groups.test.ts`、8 ケース)

- `GET /v1/groups` 認証ヘッダ無し → 401
- `POST /v1/groups` → 201 + DB 上で group / membership 双方が存在
- `POST /v1/groups` name 空文字 → 400 (zod は 422 だが既存 onError が一部 zod を 400 に落とす整合)
- `GET /v1/groups` → 自分の group のみ含まれる（他ユーザーの group は混入しない）
- `GET /v1/groups/:id` 非 member → 404
- `PATCH /v1/groups/:id` OWNER → 200 + 名前更新確認
- `PATCH /v1/groups/:id` EDITOR → 403
- `PATCH /v1/groups/:id` 非 member → 404

`seed.ts` に `seedUser` / `seedGroupWithMembership` / `seedMembership` のユーティリティを追加。

## スコープ外 / Out of scope

- DELETE / soft delete (`deletedAt`) — Issue 仕様で次フェーズへ
- `/v1/memberships` (招待 / role 変更 / 削除) — #68
- group 認可 middleware の横断版 — #69
- `createdBy` を API I/O で返すかの最終判断（現状は返している。CodeRabbit / レビューで再検討）
- ProductMaster や items の更新（モバイル MVP 後段）

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/api typecheck` 通過
- [x] `bun x oxlint apps/core/api` warnings 0 / errors 0
- [x] `bun x oxfmt --check apps/core/api` 通過
- [x] `bun --filter @prep-hamster/api test:e2e` ローカルで 14/14 pass（既存 6 + 新規 8）
- [ ] CI E2E（GitHub Actions postgres:17 service）の green 確認
- [ ] CodeRabbit レビュー 1 周

## 関連 Issue / Links

- Closes #67
- Refs #69 (group authorization middleware), #68 (memberships)
- Refs `docs/flow/v1.0.0/mobile-mvp.md` 8 章 実装順

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * グループAPI の追加：ユーザーはグループの作成、一覧表示、詳細取得が可能に
  * グループ管理機能：グループ名の更新（所有者のみ）
  * メンバーシップ管理：役割ベースのアクセス制御（OWNER、EDITOR、VIEWER）に対応
  * 認証・認可チェック：グループ操作のセキュリティが強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->