### PR TITLE
feat(api): add /v1/locations and /v1/categories CRUD

### DIFF
--- a/apps/core/api/e2e/categories.test.ts
+++ b/apps/core/api/e2e/categories.test.ts
@@ -1,0 +1,131 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { categories } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import { seedCategory, seedGroupWithMembership, seedItem, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("POST /v1/categories by OWNER returns 201", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/categories", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, name: "Food", sortOrder: 1 }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { category: { id: string; name: string; sortOrder: number } }
+  expect(body.category.name).toBe("Food")
+  expect(body.category.sortOrder).toBe(1)
+})
+
+test("POST /v1/categories by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/categories", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ groupId, name: "Food" }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})
+
+test("GET /v1/categories?groupId=X returns ordered list (sortOrder asc, NULL last)", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  await seedCategory(groupId, "Misc", null)
+  await seedCategory(groupId, "Food", 1)
+  await seedCategory(groupId, "Drink", 2)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/categories?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { categories: { name: string }[] }
+  expect(body.categories.map((c) => c.name)).toEqual(["Food", "Drink", "Misc"])
+})
+
+test("GET /v1/categories?groupId=X by non-member returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/categories?groupId=${groupId}`, {
+    headers: { "x-user-id": outsiderId },
+  })
+
+  expect(res.status).toBe(403)
+})
+
+test("PATCH /v1/categories/:id by EDITOR returns 200", async () => {
+  const ownerId = await seedUser("Owner")
+  const editorId = await seedUser("Editor")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(editorId, groupId, "EDITOR")
+  const categoryId = await seedCategory(groupId, "Food")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/categories/${categoryId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": editorId },
+    body: JSON.stringify({ name: "Food & Drink" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { category: { name: string } }
+  expect(body.category.name).toBe("Food & Drink")
+})
+
+test("DELETE /v1/categories/:id without children returns 204 + soft-delete", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const categoryId = await seedCategory(groupId, "Food")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/categories/${categoryId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(204)
+  const [row] = await testDb.select().from(categories).where(eq(categories.id, categoryId))
+  expect(row?.deletedAt).not.toBeNull()
+})
+
+test("DELETE /v1/categories/:id with referencing item returns 422 CATEGORY_IN_USE", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const categoryId = await seedCategory(groupId, "Food")
+  await seedItem(groupId, "Canned Tomato", categoryId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/categories/${categoryId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("CATEGORY_IN_USE")
+})

--- a/apps/core/api/e2e/locations.test.ts
+++ b/apps/core/api/e2e/locations.test.ts
@@ -1,0 +1,187 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { locations } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import {
+  seedGroupWithMembership,
+  seedItem,
+  seedLocation,
+  seedMembership,
+  seedStock,
+  seedUser,
+} from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("POST /v1/locations by OWNER returns 201", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/locations", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, name: "Pantry", sortOrder: 1 }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { location: { id: string; name: string; sortOrder: number } }
+  expect(body.location.name).toBe("Pantry")
+  expect(body.location.sortOrder).toBe(1)
+})
+
+test("POST /v1/locations by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/locations", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ groupId, name: "Pantry" }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})
+
+test("POST /v1/locations by non-member returns 403 FORBIDDEN_GROUP_ACCESS", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/locations", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": outsiderId },
+    body: JSON.stringify({ groupId, name: "Sneak Pantry" }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
+})
+
+test("GET /v1/locations?groupId=X returns ordered list (sortOrder asc, NULL last)", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  await seedLocation(groupId, "Garage", null)
+  await seedLocation(groupId, "Pantry", 1)
+  await seedLocation(groupId, "Fridge", 2)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { locations: { name: string; sortOrder: number | null }[] }
+  expect(body.locations.map((l) => l.name)).toEqual(["Pantry", "Fridge", "Garage"])
+})
+
+test("GET /v1/locations?groupId=X by non-member returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations?groupId=${groupId}`, {
+    headers: { "x-user-id": outsiderId },
+  })
+
+  expect(res.status).toBe(403)
+})
+
+test("GET /v1/locations/:id by non-member returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  const locationId = await seedLocation(groupId, "Pantry")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations/${locationId}`, {
+    headers: { "x-user-id": outsiderId },
+  })
+
+  expect(res.status).toBe(403)
+})
+
+test("PATCH /v1/locations/:id by EDITOR returns 200", async () => {
+  const ownerId = await seedUser("Owner")
+  const editorId = await seedUser("Editor")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(editorId, groupId, "EDITOR")
+  const locationId = await seedLocation(groupId, "Pantry")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations/${locationId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": editorId },
+    body: JSON.stringify({ name: "Pantry (Renamed)" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { location: { name: string } }
+  expect(body.location.name).toBe("Pantry (Renamed)")
+})
+
+test("PATCH /v1/locations/:id by VIEWER returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+  const locationId = await seedLocation(groupId, "Pantry")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations/${locationId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ name: "Hijack" }),
+  })
+
+  expect(res.status).toBe(403)
+})
+
+test("DELETE /v1/locations/:id without children returns 204 + soft-delete row", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const locationId = await seedLocation(groupId, "Pantry")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations/${locationId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(204)
+  const [row] = await testDb.select().from(locations).where(eq(locations.id, locationId))
+  expect(row?.deletedAt).not.toBeNull()
+})
+
+test("DELETE /v1/locations/:id with referencing stock returns 422 LOCATION_IN_USE", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const locationId = await seedLocation(groupId, "Pantry")
+  const itemId = await seedItem(groupId, "Canned Tomato")
+  await seedStock(groupId, itemId, locationId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/locations/${locationId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("LOCATION_IN_USE")
+})

--- a/apps/core/api/e2e/seed.ts
+++ b/apps/core/api/e2e/seed.ts
@@ -1,4 +1,4 @@
-import { groups, items, locations, memberships, users } from "@prep-hamster/db"
+import { categories, groups, items, locations, memberships, stocks, users } from "@prep-hamster/db"
 import { testDb } from "./setup"
 
 export type SeedFixture = {
@@ -51,6 +51,58 @@ export async function seedMembership(
     groupId,
     role,
     joinedAt: new Date(),
+  })
+  return id
+}
+
+export async function seedLocation(
+  groupId: string,
+  name = "Pantry",
+  sortOrder: number | null = null,
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await testDb.insert(locations).values({ id, groupId, name, sortOrder })
+  return id
+}
+
+export async function seedCategory(
+  groupId: string,
+  name = "Food",
+  sortOrder: number | null = null,
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await testDb.insert(categories).values({ id, groupId, name, sortOrder })
+  return id
+}
+
+export async function seedItem(
+  groupId: string,
+  name = "Canned Tomato",
+  categoryId: string | null = null,
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await testDb.insert(items).values({ id, groupId, name, categoryId })
+  return id
+}
+
+export async function seedStock(
+  groupId: string,
+  itemId: string,
+  locationId: string,
+  quantity = 1,
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await testDb.insert(stocks).values({
+    id,
+    groupId,
+    itemId,
+    locationId,
+    quantity,
+    unit: "個",
+    useByDate: null,
+    bestBeforeDate: null,
+    openedAt: null,
+    note: null,
   })
   return id
 }

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -4,7 +4,9 @@ import type { Db } from "@prep-hamster/db"
 import { withUserAuth } from "./middleware/auth"
 import { withDb } from "./middleware/db"
 import { onError } from "./middleware/error"
+import { categoriesRouter } from "./routes/categories"
 import { groupsRouter } from "./routes/groups"
+import { locationsRouter } from "./routes/locations"
 import { stocksRouter } from "./routes/stocks"
 
 export type AppEnv = {
@@ -38,6 +40,8 @@ export function createApp(opts: { db: Db }) {
   return app
     .get("/health", (c) => c.json({ ok: true as const }))
     .route("/v1/groups", groupsRouter)
+    .route("/v1/locations", locationsRouter)
+    .route("/v1/categories", categoriesRouter)
     .route("/v1/stocks", stocksRouter)
 }
 

--- a/apps/core/api/src/middleware/group-access.ts
+++ b/apps/core/api/src/middleware/group-access.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono"
 import { createMiddleware } from "hono/factory"
 import { and, eq, isNull } from "drizzle-orm"
 import { z } from "@hono/zod-openapi"
-import { memberships } from "@prep-hamster/db"
+import { type Db, memberships } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
 import type { ApiErrorBody } from "./error"
 
@@ -24,6 +24,76 @@ export type ExtractGroupId = (c: Context) => string | undefined
 
 const uuidSchema = z.string().uuid()
 
+export type GroupAccessFailure = {
+  ok: false
+  status: 403
+  body: ApiErrorBody
+}
+
+export type GroupAccessSuccess = {
+  ok: true
+  membership: Membership
+}
+
+export type GroupAccessResult = GroupAccessSuccess | GroupAccessFailure
+
+// middleware から呼ぶ場合と、body.groupId / 関連リソース経由でしか groupId を解決できない
+// handler から呼ぶ場合の両方で使えるよう、純関数として切り出した。
+//
+// groupId の UUID validation は呼び出し側 (body schema / middleware) で済ませている前提。
+// ここでは認可ロジックだけに専念する。
+export async function checkGroupAccess(
+  db: Db,
+  userId: string,
+  groupId: string,
+  requiredRole?: Role,
+): Promise<GroupAccessResult> {
+  const [member] = await db
+    .select()
+    .from(memberships)
+    .where(
+      and(
+        eq(memberships.userId, userId),
+        eq(memberships.groupId, groupId),
+        isNull(memberships.deletedAt),
+      ),
+    )
+    .limit(1)
+
+  if (!member) {
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: {
+          code: "FORBIDDEN_GROUP_ACCESS",
+          message: "この group に対するアクセス権がありません",
+        },
+      },
+    }
+  }
+
+  if (requiredRole) {
+    // DB に想定外の role 文字列が入っていた場合は fail-closed で拒否する。
+    // pgEnum で型は守られているはずだが、認可処理なので防御的に未知値を弾く。
+    const memberRoleRank = ROLE_RANK[member.role as Role]
+    if (memberRoleRank == null || memberRoleRank < ROLE_RANK[requiredRole]) {
+      return {
+        ok: false,
+        status: 403,
+        body: {
+          error: {
+            code: "INSUFFICIENT_ROLE",
+            message: `${requiredRole} 以上の権限が必要です`,
+          },
+        },
+      }
+    }
+  }
+
+  return { ok: true, membership: member }
+}
+
 export const withGroupAccess = (extractGroupId: ExtractGroupId, requiredRole?: Role) =>
   createMiddleware<AppEnv & GroupAccessEnv>(async (c, next) => {
     const groupId = extractGroupId(c)
@@ -39,51 +109,15 @@ export const withGroupAccess = (extractGroupId: ExtractGroupId, requiredRole?: R
       )
     }
 
-    const userId = c.get("userId")
     const db = c.get("db")
+    const userId = c.get("userId")
 
-    const [member] = await db
-      .select()
-      .from(memberships)
-      .where(
-        and(
-          eq(memberships.userId, userId),
-          eq(memberships.groupId, groupId),
-          isNull(memberships.deletedAt),
-        ),
-      )
-      .limit(1)
-
-    if (!member) {
-      return c.json<ApiErrorBody>(
-        {
-          error: {
-            code: "FORBIDDEN_GROUP_ACCESS",
-            message: "この group に対するアクセス権がありません",
-          },
-        },
-        403,
-      )
+    const result = await checkGroupAccess(db, userId, groupId, requiredRole)
+    if (!result.ok) {
+      return c.json<ApiErrorBody>(result.body, result.status)
     }
 
-    if (requiredRole) {
-      // DB に想定外の role 文字列が入っていた場合は fail-closed で拒否する。
-      // pgEnum で型は守られているはずだが、認可処理なので防御的に未知値を弾く。
-      const memberRoleRank = ROLE_RANK[member.role as Role]
-      if (memberRoleRank == null || memberRoleRank < ROLE_RANK[requiredRole]) {
-        return c.json<ApiErrorBody>(
-          {
-            error: {
-              code: "INSUFFICIENT_ROLE",
-              message: `${requiredRole} 以上の権限が必要です`,
-            },
-          },
-          403,
-        )
-      }
-    }
-
-    c.set("membership", member)
+    c.set("membership", result.membership)
     await next()
     return
   })

--- a/apps/core/api/src/routes/categories.ts
+++ b/apps/core/api/src/routes/categories.ts
@@ -1,0 +1,319 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, asc, eq, isNull } from "drizzle-orm"
+import { categories, items } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
+import {
+  categoryDtoSchema,
+  createCategoryBodyDtoSchema,
+  errorResponseSchema,
+  updateCategoryBodyDtoSchema,
+} from "./schemas"
+
+const IdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "id", in: "path" } }),
+})
+
+const ListQuerySchema = z.object({
+  groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
+})
+
+const toCategoryDto = (row: typeof categories.$inferSelect): z.infer<typeof categoryDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  name: row.name,
+  sortOrder: row.sortOrder,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const listCategoriesRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["categories"],
+  summary: "group 単位で category 一覧",
+  middleware: [withGroupAccess((c) => c.req.query("groupId"))] as const,
+  request: { query: ListQuerySchema },
+  responses: {
+    200: {
+      description: "一覧",
+      content: {
+        "application/json": {
+          schema: z.object({ categories: z.array(categoryDtoSchema) }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "クエリ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createCategoryRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["categories"],
+  summary: "category を作成 (EDITOR 以上)",
+  request: {
+    body: { content: { "application/json": { schema: createCategoryBodyDtoSchema } } },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": { schema: z.object({ category: categoryDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const getCategoryRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["categories"],
+  summary: "category 単件取得",
+  request: { params: IdParamSchema },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": { schema: z.object({ category: categoryDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchCategoryRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["categories"],
+  summary: "category を更新 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: updateCategoryBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": { schema: z.object({ category: categoryDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const deleteCategoryRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["categories"],
+  summary: "category を soft delete (EDITOR 以上)",
+  request: { params: IdParamSchema },
+  responses: {
+    204: { description: "削除成功" },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "子 item が参照中",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const categoriesRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listCategoriesRoute, async (c) => {
+    const { groupId } = c.req.valid("query")
+    const db = c.get("db")
+
+    const rows = await db
+      .select()
+      .from(categories)
+      .where(and(eq(categories.groupId, groupId), isNull(categories.deletedAt)))
+      .orderBy(asc(categories.sortOrder), asc(categories.name))
+
+    return c.json({ categories: rows.map(toCategoryDto) }, 200)
+  })
+  .openapi(createCategoryRoute, async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const access = await checkGroupAccess(db, userId, body.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const [created] = await db
+      .insert(categories)
+      .values({
+        id: crypto.randomUUID(),
+        groupId: body.groupId,
+        name: body.name,
+        sortOrder: body.sortOrder ?? null,
+      })
+      .returning()
+    if (!created) {
+      throw new Error("category insert returned no row")
+    }
+    return c.json({ category: toCategoryDto(created) }, 201)
+  })
+  .openapi(getCategoryRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [row] = await db
+      .select()
+      .from(categories)
+      .where(and(eq(categories.id, id), isNull(categories.deletedAt)))
+      .limit(1)
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "category が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, row.groupId)
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    return c.json({ category: toCategoryDto(row) }, 200)
+  })
+  .openapi(patchCategoryRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(categories)
+      .where(and(eq(categories.id, id), isNull(categories.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "category が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const updates: Partial<typeof categories.$inferInsert> = { updatedAt: new Date() }
+    if (body.name !== undefined) updates.name = body.name
+    if (body.sortOrder !== undefined) updates.sortOrder = body.sortOrder
+
+    const [row] = await db
+      .update(categories)
+      .set(updates)
+      .where(and(eq(categories.id, id), isNull(categories.deletedAt)))
+      .returning()
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "category が見つかりません" } }, 404)
+    }
+    return c.json({ category: toCategoryDto(row) }, 200)
+  })
+  .openapi(deleteCategoryRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(categories)
+      .where(and(eq(categories.id, id), isNull(categories.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "category が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const [referencingItem] = await db
+      .select({ id: items.id })
+      .from(items)
+      .where(and(eq(items.categoryId, id), isNull(items.deletedAt)))
+      .limit(1)
+    if (referencingItem) {
+      return c.json(
+        {
+          error: {
+            code: "CATEGORY_IN_USE",
+            message: "この category を参照している item が存在するため削除できません",
+          },
+        },
+        422,
+      )
+    }
+
+    await db
+      .update(categories)
+      .set({ deletedAt: new Date() })
+      .where(and(eq(categories.id, id), isNull(categories.deletedAt)))
+
+    return c.body(null, 204)
+  })

--- a/apps/core/api/src/routes/locations.ts
+++ b/apps/core/api/src/routes/locations.ts
@@ -1,0 +1,320 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, asc, eq, isNull } from "drizzle-orm"
+import { locations, stocks } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
+import {
+  createLocationBodyDtoSchema,
+  errorResponseSchema,
+  locationDtoSchema,
+  updateLocationBodyDtoSchema,
+} from "./schemas"
+
+const IdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "id", in: "path" } }),
+})
+
+const ListQuerySchema = z.object({
+  groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
+})
+
+const toLocationDto = (row: typeof locations.$inferSelect): z.infer<typeof locationDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  name: row.name,
+  sortOrder: row.sortOrder,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const listLocationsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["locations"],
+  summary: "group 単位で location 一覧",
+  middleware: [withGroupAccess((c) => c.req.query("groupId"))] as const,
+  request: { query: ListQuerySchema },
+  responses: {
+    200: {
+      description: "一覧",
+      content: {
+        "application/json": {
+          schema: z.object({ locations: z.array(locationDtoSchema) }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "クエリ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createLocationRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["locations"],
+  summary: "location を作成 (EDITOR 以上)",
+  request: {
+    body: { content: { "application/json": { schema: createLocationBodyDtoSchema } } },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": { schema: z.object({ location: locationDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const getLocationRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["locations"],
+  summary: "location 単件取得",
+  request: { params: IdParamSchema },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": { schema: z.object({ location: locationDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchLocationRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["locations"],
+  summary: "location を更新 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: updateLocationBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": { schema: z.object({ location: locationDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const deleteLocationRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["locations"],
+  summary: "location を soft delete (EDITOR 以上)",
+  request: { params: IdParamSchema },
+  responses: {
+    204: { description: "削除成功" },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "子 stock が参照中",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const locationsRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listLocationsRoute, async (c) => {
+    const { groupId } = c.req.valid("query")
+    const db = c.get("db")
+
+    const rows = await db
+      .select()
+      .from(locations)
+      .where(and(eq(locations.groupId, groupId), isNull(locations.deletedAt)))
+      .orderBy(asc(locations.sortOrder), asc(locations.name))
+
+    return c.json({ locations: rows.map(toLocationDto) }, 200)
+  })
+  .openapi(createLocationRoute, async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const access = await checkGroupAccess(db, userId, body.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const [created] = await db
+      .insert(locations)
+      .values({
+        id: crypto.randomUUID(),
+        groupId: body.groupId,
+        name: body.name,
+        sortOrder: body.sortOrder ?? null,
+      })
+      .returning()
+    if (!created) {
+      throw new Error("location insert returned no row")
+    }
+    return c.json({ location: toLocationDto(created) }, 201)
+  })
+  .openapi(getLocationRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [row] = await db
+      .select()
+      .from(locations)
+      .where(and(eq(locations.id, id), isNull(locations.deletedAt)))
+      .limit(1)
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "location が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, row.groupId)
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    return c.json({ location: toLocationDto(row) }, 200)
+  })
+  .openapi(patchLocationRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(locations)
+      .where(and(eq(locations.id, id), isNull(locations.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "location が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const updates: Partial<typeof locations.$inferInsert> = { updatedAt: new Date() }
+    if (body.name !== undefined) updates.name = body.name
+    if (body.sortOrder !== undefined) updates.sortOrder = body.sortOrder
+
+    const [row] = await db
+      .update(locations)
+      .set(updates)
+      .where(and(eq(locations.id, id), isNull(locations.deletedAt)))
+      .returning()
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "location が見つかりません" } }, 404)
+    }
+    return c.json({ location: toLocationDto(row) }, 200)
+  })
+  .openapi(deleteLocationRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(locations)
+      .where(and(eq(locations.id, id), isNull(locations.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "location が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    // 子 stock が参照していたら 422 (cascade ルールは v1.0.0 では「参照ありなら blocked」に統一)
+    const [referencingStock] = await db
+      .select({ id: stocks.id })
+      .from(stocks)
+      .where(and(eq(stocks.locationId, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (referencingStock) {
+      return c.json(
+        {
+          error: {
+            code: "LOCATION_IN_USE",
+            message: "この location を参照している stock が存在するため削除できません",
+          },
+        },
+        422,
+      )
+    }
+
+    await db
+      .update(locations)
+      .set({ deletedAt: new Date() })
+      .where(and(eq(locations.id, id), isNull(locations.deletedAt)))
+
+    return c.body(null, 204)
+  })

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -52,6 +52,60 @@ export const updateGroupBodyDtoSchema = z
   })
   .openapi("UpdateGroupBody")
 
+export const locationDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    name: z.string(),
+    sortOrder: z.number().int().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Location")
+
+export const createLocationBodyDtoSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    name: z.string().min(1).max(100),
+    sortOrder: z.number().int().nullable().optional(),
+  })
+  .openapi("CreateLocationBody")
+
+export const updateLocationBodyDtoSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    sortOrder: z.number().int().nullable().optional(),
+  })
+  .openapi("UpdateLocationBody")
+
+export const categoryDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    name: z.string(),
+    sortOrder: z.number().int().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Category")
+
+export const createCategoryBodyDtoSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    name: z.string().min(1).max(100),
+    sortOrder: z.number().int().nullable().optional(),
+  })
+  .openapi("CreateCategoryBody")
+
+export const updateCategoryBodyDtoSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    sortOrder: z.number().int().nullable().optional(),
+  })
+  .openapi("UpdateCategoryBody")
+
 export const stockDtoSchema = z
   .object({
     id: z.string().uuid(),


### PR DESCRIPTION
## 概要 / Why

在庫の保管場所 (`locations`: 自宅キッチン / 物置 等) とカテゴリ (`categories`: 食品 / 飲料 等) は group ごとに自由に作る軽量マスタ。stocks や items が参照する。スキーマ・操作がほぼ同形なので 1 PR で扱う。

UC-04「在庫の保管場所を移動」と UC-06「カテゴリ・保管場所で絞り込み」の前提。

## 変更内容 / What

### `/v1/locations` (5 endpoint)
- `POST /v1/locations` body: `{ groupId, name, sortOrder? }` → 201
- `GET /v1/locations?groupId=...` → group 単位で一覧 (sortOrder ASC、NULL は末尾)
- `GET /v1/locations/:id` → 単件
- `PATCH /v1/locations/:id` → name / sortOrder 変更
- `DELETE /v1/locations/:id` → soft delete (deletedAt set)
  - 子 stock が参照中なら 422 `LOCATION_IN_USE`

### `/v1/categories` (5 endpoint)
- 同形 (DELETE 時は item 参照で 422 `CATEGORY_IN_USE`)

### 認可
- 全 endpoint で group メンバー必須
- 一覧 (query.groupId) は `withGroupAccess` middleware
- それ以外 (path.id を持つ系 + body.groupId 系) は handler 内で `checkGroupAccess` を呼ぶ
  - middleware は body 読込みが validator と衝突するため、共通ロジックを純関数化して両方で使える形にした
- 編集系 (POST / PATCH / DELETE) は EDITOR 以上必須

### スキーマ
- `routes/schemas.ts` に `locationDtoSchema` / `categoryDtoSchema` + create/update body 追加
- ISO string + plain UUID で API 境界を統一 (branded type は内部のみ)

### E2E
- `locations.test.ts` 11 case / `categories.test.ts` 7 case
- CRUD ハッピーパス + 認可エラー (非 member / VIEWER) + soft delete + cascade block

## 設計判断

- 1 PR で 2 リソースを一緒に扱う（構造ほぼ同形でレビュー観点が同じ）
- DELETE の cascade ルールは v1.0.0 では「参照ありなら 422」で統一（最もシンプル）
- `checkGroupAccess` を `withGroupAccess` から切り出して両方から使えるように。groupId UUID validation は呼び出し側（zod body schema / middleware）で済ませる前提に変更し、関数の status を `403` のみに narrow

## スコープ外 / Out of scope

- カテゴリの階層化 / 親子関係
- アイコン / 色のマスタ管理 (UI 側で持つ)
- DnD 用 sortOrder 一括更新 endpoint
- 子参照ありの強制削除フロー (force delete)

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/api typecheck`
- [x] `bun --filter @prep-hamster/api test:e2e` → 36 pass / 0 fail (うち 18 が #70)
- [x] `bun x oxlint apps/core/api/src apps/core/api/e2e` → 0 errors
- [x] `bun x oxfmt --check apps/core/api/src apps/core/api/e2e` → ok

## 関連 Issue / Links

- Closes #70
- Base: #80 (#69 group authorization middleware)
- Depends on: #67 (#79), #69 (#80)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない