### PR TITLE
feat(api): add /v1/items CRUD (manual entry)

### DIFF
--- a/apps/core/api/e2e/items.test.ts
+++ b/apps/core/api/e2e/items.test.ts
@@ -138,6 +138,7 @@ test("GET /v1/items?groupId=X&categoryId=Y filters", async () => {
     headers: { "x-user-id": userId },
   })
 
+  expect(res.status).toBe(200)
   const body = (await res.json()) as { items: { name: string }[] }
   expect(body.items.map((i) => i.name)).toEqual(["Apple"])
 })

--- a/apps/core/api/e2e/items.test.ts
+++ b/apps/core/api/e2e/items.test.ts
@@ -1,0 +1,223 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { items } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import {
+  seedCategory,
+  seedGroupWithMembership,
+  seedItem,
+  seedLocation,
+  seedMembership,
+  seedStock,
+  seedUser,
+} from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("POST /v1/items by OWNER returns 201", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/items", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({
+      groupId,
+      name: "Canned Tomato",
+      defaultUnit: "缶",
+      barcode: "4901234567890",
+    }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as {
+    item: { name: string; productMasterId: string | null; barcode: string | null }
+  }
+  expect(body.item.name).toBe("Canned Tomato")
+  expect(body.item.productMasterId).toBeNull()
+  expect(body.item.barcode).toBe("4901234567890")
+})
+
+test("POST /v1/items by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/items", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ groupId, name: "Sneak" }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})
+
+test("POST /v1/items with another group's categoryId returns 422 CATEGORY_GROUP_MISMATCH", async () => {
+  const userId = await seedUser()
+  const homeGroup = await seedGroupWithMembership(userId, "Home")
+  const otherOwner = await seedUser("Other")
+  const otherGroup = await seedGroupWithMembership(otherOwner, "Other")
+  const otherCategory = await seedCategory(otherGroup, "Food")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/items", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({
+      groupId: homeGroup,
+      name: "Foreign-Category Item",
+      categoryId: otherCategory,
+    }),
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("CATEGORY_GROUP_MISMATCH")
+})
+
+test("POST /v1/items with duplicate (groupId, barcode) returns 422 ITEM_BARCODE_DUPLICATE", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb })
+  await app.request("/v1/items", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, name: "First", barcode: "4901234567890" }),
+  })
+
+  const res = await app.request("/v1/items", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, name: "Second", barcode: "4901234567890" }),
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("ITEM_BARCODE_DUPLICATE")
+})
+
+test("GET /v1/items?groupId=X returns active items only", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  await seedItem(groupId, "Apple")
+  await seedItem(groupId, "Banana")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { items: { name: string }[] }
+  expect(body.items.map((i) => i.name).toSorted()).toEqual(["Apple", "Banana"])
+})
+
+test("GET /v1/items?groupId=X&categoryId=Y filters", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const foodCat = await seedCategory(groupId, "Food")
+  const drinkCat = await seedCategory(groupId, "Drink")
+  await seedItem(groupId, "Apple", foodCat)
+  await seedItem(groupId, "Coffee", drinkCat)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items?groupId=${groupId}&categoryId=${foodCat}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  const body = (await res.json()) as { items: { name: string }[] }
+  expect(body.items.map((i) => i.name)).toEqual(["Apple"])
+})
+
+test("GET /v1/items/:id by non-member returns 403", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  const itemId = await seedItem(groupId, "Apple")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items/${itemId}`, {
+    headers: { "x-user-id": outsiderId },
+  })
+  expect(res.status).toBe(403)
+})
+
+test("PATCH /v1/items/:id by EDITOR updates barcode", async () => {
+  const ownerId = await seedUser("Owner")
+  const editorId = await seedUser("Editor")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(editorId, groupId, "EDITOR")
+  const itemId = await seedItem(groupId, "Apple")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items/${itemId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": editorId },
+    body: JSON.stringify({ barcode: "4900000000000" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { item: { barcode: string | null } }
+  expect(body.item.barcode).toBe("4900000000000")
+})
+
+test("DELETE /v1/items/:id without active stock returns 204 + soft-delete", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const itemId = await seedItem(groupId, "Apple")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items/${itemId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(204)
+  const [row] = await testDb.select().from(items).where(eq(items.id, itemId))
+  expect(row?.deletedAt).not.toBeNull()
+})
+
+test("DELETE /v1/items/:id with active stock returns 422 ITEM_IN_USE", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const itemId = await seedItem(groupId, "Apple")
+  const locationId = await seedLocation(groupId, "Pantry")
+  await seedStock(groupId, itemId, locationId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items/${itemId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("ITEM_IN_USE")
+})
+
+test("GET /v1/items/:id soft-deleted returns 404", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const itemId = await seedItem(groupId, "Apple")
+  await testDb.update(items).set({ deletedAt: new Date() }).where(eq(items.id, itemId))
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/items/${itemId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(404)
+})

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -6,6 +6,7 @@ import { withDb } from "./middleware/db"
 import { onError } from "./middleware/error"
 import { categoriesRouter } from "./routes/categories"
 import { groupsRouter } from "./routes/groups"
+import { itemsRouter } from "./routes/items"
 import { locationsRouter } from "./routes/locations"
 import { stocksRouter } from "./routes/stocks"
 
@@ -42,6 +43,7 @@ export function createApp(opts: { db: Db }) {
     .route("/v1/groups", groupsRouter)
     .route("/v1/locations", locationsRouter)
     .route("/v1/categories", categoriesRouter)
+    .route("/v1/items", itemsRouter)
     .route("/v1/stocks", stocksRouter)
 }
 

--- a/apps/core/api/src/routes/items.ts
+++ b/apps/core/api/src/routes/items.ts
@@ -1,0 +1,427 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, asc, eq, isNull } from "drizzle-orm"
+import { categories, items, stocks } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
+import {
+  createItemBodyDtoSchema,
+  errorResponseSchema,
+  itemDtoSchema,
+  updateItemBodyDtoSchema,
+} from "./schemas"
+
+const IdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "id", in: "path" } }),
+})
+
+const ListQuerySchema = z.object({
+  groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
+  categoryId: z.string().uuid().optional(),
+  barcode: z.string().optional(),
+})
+
+const toItemDto = (row: typeof items.$inferSelect): z.infer<typeof itemDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  productMasterId: row.productMasterId,
+  name: row.name,
+  barcode: row.barcode,
+  categoryId: row.categoryId,
+  defaultUnit: row.defaultUnit,
+  manufacturer: row.manufacturer,
+  memo: row.memo,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+// categoryId が同じ group に属するか検証する。null なら check 不要。
+async function assertCategoryInGroup(
+  db: AppEnv["Variables"]["db"],
+  categoryId: string | null | undefined,
+  groupId: string,
+): Promise<true | { code: string; message: string }> {
+  if (!categoryId) return true
+  const [row] = await db
+    .select({ groupId: categories.groupId })
+    .from(categories)
+    .where(and(eq(categories.id, categoryId), isNull(categories.deletedAt)))
+    .limit(1)
+  if (!row || row.groupId !== groupId) {
+    return {
+      code: "CATEGORY_GROUP_MISMATCH",
+      message: "categoryId が同じ group に属していません",
+    }
+  }
+  return true
+}
+
+// 同じ groupId + barcode の active item が既にいないか確認する。
+// DB 側にも `(group_id, barcode) WHERE product_master_id IS NULL AND barcode IS NOT NULL`
+// の uniqueIndex があるが、明示的に事前 check してわかりやすい 422 を返す。
+async function findDuplicateBarcode(
+  db: AppEnv["Variables"]["db"],
+  groupId: string,
+  barcode: string,
+  excludeItemId?: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: items.id })
+    .from(items)
+    .where(
+      and(
+        eq(items.groupId, groupId),
+        eq(items.barcode, barcode),
+        isNull(items.productMasterId),
+        isNull(items.deletedAt),
+      ),
+    )
+    .limit(2)
+  return rows.some((r) => r.id !== excludeItemId)
+}
+
+const listItemsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["items"],
+  summary: "group 単位で item 一覧 (categoryId / barcode 絞り込み可)",
+  middleware: [withGroupAccess((c) => c.req.query("groupId"))] as const,
+  request: { query: ListQuerySchema },
+  responses: {
+    200: {
+      description: "一覧",
+      content: {
+        "application/json": { schema: z.object({ items: z.array(itemDtoSchema) }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "クエリ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createItemRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["items"],
+  summary: "item を手動作成 (EDITOR 以上)",
+  request: {
+    body: { content: { "application/json": { schema: createItemBodyDtoSchema } } },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": { schema: z.object({ item: itemDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正 / barcode 重複 / category 不整合",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const getItemRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["items"],
+  summary: "item 単件取得",
+  request: { params: IdParamSchema },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": { schema: z.object({ item: itemDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchItemRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["items"],
+  summary: "item を更新 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: updateItemBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": { schema: z.object({ item: itemDtoSchema }) },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正 / barcode 重複 / category 不整合",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const deleteItemRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["items"],
+  summary: "item を soft delete (EDITOR 以上)",
+  request: { params: IdParamSchema },
+  responses: {
+    204: { description: "削除成功" },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "active stock が参照中",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const itemsRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listItemsRoute, async (c) => {
+    const { groupId, categoryId, barcode } = c.req.valid("query")
+    const db = c.get("db")
+
+    const conditions = [eq(items.groupId, groupId), isNull(items.deletedAt)]
+    if (categoryId) conditions.push(eq(items.categoryId, categoryId))
+    if (barcode) conditions.push(eq(items.barcode, barcode))
+
+    const rows = await db
+      .select()
+      .from(items)
+      .where(and(...conditions))
+      .orderBy(asc(items.name))
+
+    return c.json({ items: rows.map(toItemDto) }, 200)
+  })
+  .openapi(createItemRoute, async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const access = await checkGroupAccess(db, userId, body.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const categoryCheck = await assertCategoryInGroup(db, body.categoryId, body.groupId)
+    if (categoryCheck !== true) {
+      return c.json({ error: categoryCheck }, 422)
+    }
+
+    if (body.barcode) {
+      const dup = await findDuplicateBarcode(db, body.groupId, body.barcode)
+      if (dup) {
+        return c.json(
+          {
+            error: {
+              code: "ITEM_BARCODE_DUPLICATE",
+              message: "同じ group に同じ barcode の item が既に存在します",
+            },
+          },
+          422,
+        )
+      }
+    }
+
+    const [created] = await db
+      .insert(items)
+      .values({
+        id: crypto.randomUUID(),
+        groupId: body.groupId,
+        productMasterId: null,
+        name: body.name,
+        barcode: body.barcode ?? null,
+        categoryId: body.categoryId ?? null,
+        defaultUnit: body.defaultUnit ?? null,
+        manufacturer: body.manufacturer ?? null,
+        memo: body.memo ?? null,
+      })
+      .returning()
+    if (!created) {
+      throw new Error("item insert returned no row")
+    }
+    return c.json({ item: toItemDto(created) }, 201)
+  })
+  .openapi(getItemRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [row] = await db
+      .select()
+      .from(items)
+      .where(and(eq(items.id, id), isNull(items.deletedAt)))
+      .limit(1)
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, row.groupId)
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    return c.json({ item: toItemDto(row) }, 200)
+  })
+  .openapi(patchItemRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(items)
+      .where(and(eq(items.id, id), isNull(items.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    if (body.categoryId !== undefined) {
+      const categoryCheck = await assertCategoryInGroup(db, body.categoryId, existing.groupId)
+      if (categoryCheck !== true) {
+        return c.json({ error: categoryCheck }, 422)
+      }
+    }
+
+    // barcode を変更/設定するなら同 group 内の重複を防ぐ。productMaster 紐付け済みの
+    // item は uniqueIndex のスコープ外だが、本 endpoint では productMasterId は
+    // 触らないので productMasterId IS NULL の item 同士の衝突だけ気にすれば十分。
+    if (body.barcode !== undefined && body.barcode !== null && existing.productMasterId == null) {
+      const dup = await findDuplicateBarcode(db, existing.groupId, body.barcode, id)
+      if (dup) {
+        return c.json(
+          {
+            error: {
+              code: "ITEM_BARCODE_DUPLICATE",
+              message: "同じ group に同じ barcode の item が既に存在します",
+            },
+          },
+          422,
+        )
+      }
+    }
+
+    const updates: Partial<typeof items.$inferInsert> = { updatedAt: new Date() }
+    if (body.name !== undefined) updates.name = body.name
+    if (body.categoryId !== undefined) updates.categoryId = body.categoryId
+    if (body.defaultUnit !== undefined) updates.defaultUnit = body.defaultUnit
+    if (body.manufacturer !== undefined) updates.manufacturer = body.manufacturer
+    if (body.memo !== undefined) updates.memo = body.memo
+    if (body.barcode !== undefined) updates.barcode = body.barcode
+
+    const [row] = await db
+      .update(items)
+      .set(updates)
+      .where(and(eq(items.id, id), isNull(items.deletedAt)))
+      .returning()
+    if (!row) {
+      return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+    }
+    return c.json({ item: toItemDto(row) }, 200)
+  })
+  .openapi(deleteItemRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(items)
+      .where(and(eq(items.id, id), isNull(items.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const [referencingStock] = await db
+      .select({ id: stocks.id })
+      .from(stocks)
+      .where(and(eq(stocks.itemId, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (referencingStock) {
+      return c.json(
+        {
+          error: {
+            code: "ITEM_IN_USE",
+            message: "この item を参照している active な stock が存在するため削除できません",
+          },
+        },
+        422,
+      )
+    }
+
+    await db
+      .update(items)
+      .set({ deletedAt: new Date() })
+      .where(and(eq(items.id, id), isNull(items.deletedAt)))
+
+    return c.body(null, 204)
+  })

--- a/apps/core/api/src/routes/items.ts
+++ b/apps/core/api/src/routes/items.ts
@@ -59,6 +59,24 @@ async function assertCategoryInGroup(
   return true
 }
 
+// Postgres unique violation (SQLSTATE 23505) かを判定する。
+// 事前 check と INSERT/UPDATE の間に race が発生した場合の最終防衛で使う。
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: unknown }).code === "23505"
+  )
+}
+
+const BARCODE_DUPLICATE_RESPONSE = {
+  error: {
+    code: "ITEM_BARCODE_DUPLICATE",
+    message: "同じ group に同じ barcode の item が既に存在します",
+  },
+} as const
+
 // 同じ groupId + barcode の active item が既にいないか確認する。
 // DB 側にも `(group_id, barcode) WHERE product_master_id IS NULL AND barcode IS NOT NULL`
 // の uniqueIndex があるが、明示的に事前 check してわかりやすい 422 を返す。
@@ -267,36 +285,37 @@ export const itemsRouter = new OpenAPIHono<AppEnv>()
     if (body.barcode) {
       const dup = await findDuplicateBarcode(db, body.groupId, body.barcode)
       if (dup) {
-        return c.json(
-          {
-            error: {
-              code: "ITEM_BARCODE_DUPLICATE",
-              message: "同じ group に同じ barcode の item が既に存在します",
-            },
-          },
-          422,
-        )
+        return c.json(BARCODE_DUPLICATE_RESPONSE, 422)
       }
     }
 
-    const [created] = await db
-      .insert(items)
-      .values({
-        id: crypto.randomUUID(),
-        groupId: body.groupId,
-        productMasterId: null,
-        name: body.name,
-        barcode: body.barcode ?? null,
-        categoryId: body.categoryId ?? null,
-        defaultUnit: body.defaultUnit ?? null,
-        manufacturer: body.manufacturer ?? null,
-        memo: body.memo ?? null,
-      })
-      .returning()
-    if (!created) {
-      throw new Error("item insert returned no row")
+    try {
+      const [created] = await db
+        .insert(items)
+        .values({
+          id: crypto.randomUUID(),
+          groupId: body.groupId,
+          productMasterId: null,
+          name: body.name,
+          barcode: body.barcode ?? null,
+          categoryId: body.categoryId ?? null,
+          defaultUnit: body.defaultUnit ?? null,
+          manufacturer: body.manufacturer ?? null,
+          memo: body.memo ?? null,
+        })
+        .returning()
+      if (!created) {
+        throw new Error("item insert returned no row")
+      }
+      return c.json({ item: toItemDto(created) }, 201)
+    } catch (err) {
+      // 並行リクエストで事前 check を双方通過した場合に DB の uniqueIndex で 23505。
+      // 500 として扱わずユーザーに 422 ITEM_BARCODE_DUPLICATE で返す。
+      if (isUniqueViolation(err)) {
+        return c.json(BARCODE_DUPLICATE_RESPONSE, 422)
+      }
+      throw err
     }
-    return c.json({ item: toItemDto(created) }, 201)
   })
   .openapi(getItemRoute, async (c) => {
     const { id } = c.req.valid("param")
@@ -352,15 +371,7 @@ export const itemsRouter = new OpenAPIHono<AppEnv>()
     if (body.barcode !== undefined && body.barcode !== null && existing.productMasterId == null) {
       const dup = await findDuplicateBarcode(db, existing.groupId, body.barcode, id)
       if (dup) {
-        return c.json(
-          {
-            error: {
-              code: "ITEM_BARCODE_DUPLICATE",
-              message: "同じ group に同じ barcode の item が既に存在します",
-            },
-          },
-          422,
-        )
+        return c.json(BARCODE_DUPLICATE_RESPONSE, 422)
       }
     }
 
@@ -372,15 +383,22 @@ export const itemsRouter = new OpenAPIHono<AppEnv>()
     if (body.memo !== undefined) updates.memo = body.memo
     if (body.barcode !== undefined) updates.barcode = body.barcode
 
-    const [row] = await db
-      .update(items)
-      .set(updates)
-      .where(and(eq(items.id, id), isNull(items.deletedAt)))
-      .returning()
-    if (!row) {
-      return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+    try {
+      const [row] = await db
+        .update(items)
+        .set(updates)
+        .where(and(eq(items.id, id), isNull(items.deletedAt)))
+        .returning()
+      if (!row) {
+        return c.json({ error: { code: "NOT_FOUND", message: "item が見つかりません" } }, 404)
+      }
+      return c.json({ item: toItemDto(row) }, 200)
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        return c.json(BARCODE_DUPLICATE_RESPONSE, 422)
+      }
+      throw err
     }
-    return c.json({ item: toItemDto(row) }, 200)
   })
   .openapi(deleteItemRoute, async (c) => {
     const { id } = c.req.valid("param")
@@ -418,9 +436,12 @@ export const itemsRouter = new OpenAPIHono<AppEnv>()
       )
     }
 
+    // PATCH と同様 updatedAt も touch する。差分同期 / キャッシュ無効化が
+    // updatedAt を見るクライアントから論理削除を検知できるようにするため。
+    const now = new Date()
     await db
       .update(items)
-      .set({ deletedAt: new Date() })
+      .set({ deletedAt: now, updatedAt: now })
       .where(and(eq(items.id, id), isNull(items.deletedAt)))
 
     return c.body(null, 204)

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -106,6 +106,47 @@ export const updateCategoryBodyDtoSchema = z
   })
   .openapi("UpdateCategoryBody")
 
+export const itemDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    productMasterId: z.string().uuid().nullable(),
+    name: z.string(),
+    barcode: z.string().nullable(),
+    categoryId: z.string().uuid().nullable(),
+    defaultUnit: z.string().nullable(),
+    manufacturer: z.string().nullable(),
+    memo: z.string().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Item")
+
+// 手動入力では productMasterId は指定不可（バーコード経路で別途自動紐付け）
+export const createItemBodyDtoSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    name: z.string().min(1).max(200),
+    categoryId: z.string().uuid().nullable().optional(),
+    defaultUnit: z.string().min(1).max(50).nullable().optional(),
+    manufacturer: z.string().max(200).nullable().optional(),
+    memo: z.string().max(2000).nullable().optional(),
+    barcode: z.string().min(1).max(64).nullable().optional(),
+  })
+  .openapi("CreateItemBody")
+
+export const updateItemBodyDtoSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    categoryId: z.string().uuid().nullable().optional(),
+    defaultUnit: z.string().min(1).max(50).nullable().optional(),
+    manufacturer: z.string().max(200).nullable().optional(),
+    memo: z.string().max(2000).nullable().optional(),
+    barcode: z.string().min(1).max(64).nullable().optional(),
+  })
+  .openapi("UpdateItemBody")
+
 export const stockDtoSchema = z
   .object({
     id: z.string().uuid(),


### PR DESCRIPTION
## 概要 / Why

items は group 内の品目マスタ (stocks の親)。本 Issue では手動入力経路だけを実装する。バーコード経由の自動 find-or-create は `packages/jan-api` 完成後に別 Issue (UC-02) で扱う。

## 変更内容 / What

### `/v1/items` (5 endpoint)

- `POST /v1/items` body: `{ groupId, name, categoryId?, defaultUnit?, manufacturer?, memo?, barcode? }`
  - `productMasterId` は本 endpoint では指定不可（強制 null）
- `GET /v1/items?groupId=...&categoryId=...&barcode=...` 一覧（categoryId / barcode で絞り込み可、name 昇順）
- `GET /v1/items/:id`
- `PATCH /v1/items/:id` name / categoryId / defaultUnit / manufacturer / memo / barcode を更新可
- `DELETE /v1/items/:id` soft delete。active な子 stock 参照ありなら 422 `ITEM_IN_USE`

### 認可
- 一覧は `withGroupAccess` (query.groupId)
- 単件系・編集系は handler 内 `checkGroupAccess` (path.id 経由で resource.groupId 解決)
- 編集系 (POST / PATCH / DELETE) は EDITOR 以上必須

### バリデーション
- **barcode 重複チェック**: 同じ `(groupId, barcode)` の active item が既に存在したら 422 `ITEM_BARCODE_DUPLICATE`。DB 側に `(group_id, barcode) WHERE product_master_id IS NULL AND barcode IS NOT NULL` の uniqueIndex があるが、明示的に事前 check してわかりやすいエラーを返す
- **cross-group categoryId**: `categoryId` 指定時は同 group の category かを `assertCategoryInGroup` で検証、不整合なら 422 `CATEGORY_GROUP_MISMATCH`

### スキーマ
- `routes/schemas.ts` に `itemDtoSchema` + create/update body schema 追加
- ISO string + plain UUID で API 境界統一 (branded type は内部のみ)

### E2E (`items.test.ts` 11 case)
- CRUD ハッピーパス + 認可エラー (非 member / VIEWER) + barcode duplicate + cross-group categoryId + active stock cascade block + soft-deleted 取得 404

## 設計判断

- **手動 items は productMasterId なし** で固定。バーコード経路を別 Issue で導入する際、productMasterId を後付けする余地を残す
- **DELETE cascade ルールは locations / categories / items すべて統一**: active な子参照ありなら 422 で blocked
- **categoryId 変更は許可**（品目の分類変更は運用でよくある）
- **PATCH の barcode 重複チェック** は productMasterId が null の item のみが uniqueIndex のスコープ内なので、`existing.productMasterId == null` の条件で限定

## スコープ外 / Out of scope

- バーコード経由の find-or-create 作成（UC-02 / `packages/jan-api` 連動で別 Issue）
- 商品マスタ (`productMasters`) との連結ロジック
- 画像アップロード

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/api typecheck`
- [x] `bun --filter @prep-hamster/api test:e2e` → 47 pass / 0 fail (うち 11 が #71)
- [x] `bun x oxlint apps/core/api/src apps/core/api/e2e` → 0 errors
- [x] `bun x oxfmt --check apps/core/api/src apps/core/api/e2e` → ok

## 関連 Issue / Links

- Closes #71
- Base: #81 (#70 locations/categories CRUD)
- Depends on: #67 (#79), #69 (#80), #70 (#81)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アイテム管理API機能を実装しました。アイテムの作成、取得、編集、削除操作が可能になります。グループごとのアクセス制御、データ検証、ソフト削除機能により、データの安全性と整合性が強化されました。

* **テスト**
  * アイテムAPI機能の包括的なエンドツーエンドテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->