### PR TITLE
feat(packages/jan-api): JAN code lookup → ProductMaster

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,13 @@
         "drizzle-kit": "^0.28.0",
       },
     },
+    "packages/jan-api": {
+      "name": "@prep-hamster/jan-api",
+      "version": "0.0.0",
+      "dependencies": {
+        "@prep-hamster/db": "workspace:*",
+      },
+    },
     "packages/schema": {
       "name": "@prep-hamster/schema",
       "version": "0.0.0",
@@ -230,6 +237,8 @@
     "@prep-hamster/cli-user": ["@prep-hamster/cli-user@workspace:apps/user/client/cli"],
 
     "@prep-hamster/db": ["@prep-hamster/db@workspace:packages/db"],
+
+    "@prep-hamster/jan-api": ["@prep-hamster/jan-api@workspace:packages/jan-api"],
 
     "@prep-hamster/schema": ["@prep-hamster/schema@workspace:packages/schema"],
 

--- a/packages/jan-api/package.json
+++ b/packages/jan-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@prep-hamster/jan-api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@prep-hamster/db": "workspace:*"
+  }
+}

--- a/packages/jan-api/src/client.test.ts
+++ b/packages/jan-api/src/client.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { createJanApiClient } from "./client"
+import { createDefaultProviders, createJanApiClient } from "./client"
 import type { JanProvider, ProductMasterCandidate } from "./types"
 
 const VALID_JAN = "4901234567894"
@@ -83,4 +83,24 @@ test("default chain: yahooAppId not set falls back to stub fixtures", async () =
 
   const client = createJanApiClient({ stubFixtures: fixtures })
   expect((await client.lookup(VALID_JAN))?.name).toBe("Test Product")
+})
+
+test("createDefaultProviders is publicly exposed for chain extension", () => {
+  const previousAppId = process.env["YAHOO_SHOPPING_APP_ID"]
+  delete process.env["YAHOO_SHOPPING_APP_ID"]
+  try {
+    // env yahooAppId なしなら stub だけが返る
+    const providers = createDefaultProviders()
+    expect(providers.length).toBe(1)
+    expect(providers.at(-1)?.name).toBe("fallback-stub")
+
+    // appId 指定があれば yahoo が前段に追加される
+    const withYahoo = createDefaultProviders({ yahooAppId: "test-app-id" })
+    expect(withYahoo.length).toBe(2)
+    expect(withYahoo[0]?.name).toBe("yahoo")
+  } finally {
+    if (previousAppId !== undefined) {
+      process.env["YAHOO_SHOPPING_APP_ID"] = previousAppId
+    }
+  }
 })

--- a/packages/jan-api/src/client.test.ts
+++ b/packages/jan-api/src/client.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test"
+import { createJanApiClient } from "./client"
+import type { JanProvider, ProductMasterCandidate } from "./types"
+
+const VALID_JAN = "4901234567894"
+
+const fixture = (): ProductMasterCandidate => ({
+  jan: VALID_JAN,
+  name: "Test Product",
+  manufacturer: null,
+  brand: null,
+  contentAmount: null,
+  contentUnit: null,
+  categoryHint: null,
+  imageUrl: null,
+  source: "OTHER",
+  sourceRaw: null,
+  confidence: null,
+})
+
+const provider = (name: string, hit: ProductMasterCandidate | null): JanProvider => ({
+  name,
+  async lookup() {
+    return hit
+  },
+})
+
+test("invalid JAN short-circuits without provider call", async () => {
+  let calls = 0
+  const client = createJanApiClient({
+    providers: [
+      {
+        name: "spy",
+        async lookup() {
+          calls++
+          return fixture()
+        },
+      },
+    ],
+  })
+  const result = await client.lookup("123")
+  expect(result).toBeNull()
+  expect(calls).toBe(0)
+})
+
+test("first hit wins; later providers not called", async () => {
+  let secondCalls = 0
+  const client = createJanApiClient({
+    providers: [
+      provider("first", fixture()),
+      {
+        name: "second",
+        async lookup() {
+          secondCalls++
+          return null
+        },
+      },
+    ],
+  })
+  const result = await client.lookup(VALID_JAN)
+  expect(result?.name).toBe("Test Product")
+  expect(secondCalls).toBe(0)
+})
+
+test("falls through to next provider on null", async () => {
+  const client = createJanApiClient({
+    providers: [provider("first", null), provider("second", fixture())],
+  })
+  const result = await client.lookup(VALID_JAN)
+  expect(result?.name).toBe("Test Product")
+})
+
+test("returns null when no provider hits", async () => {
+  const client = createJanApiClient({
+    providers: [provider("a", null), provider("b", null)],
+  })
+  expect(await client.lookup(VALID_JAN)).toBeNull()
+})
+
+test("default chain: yahooAppId not set falls back to stub fixtures", async () => {
+  const fixtures = new Map<string, ProductMasterCandidate>()
+  fixtures.set(VALID_JAN, fixture())
+
+  const client = createJanApiClient({ stubFixtures: fixtures })
+  expect((await client.lookup(VALID_JAN))?.name).toBe("Test Product")
+})

--- a/packages/jan-api/src/client.ts
+++ b/packages/jan-api/src/client.ts
@@ -1,0 +1,51 @@
+import { isValidJan } from "./jan"
+import { createStubProvider } from "./providers/stub"
+import { createYahooProvider } from "./providers/yahoo"
+import type { JanApiClient, JanProvider, ProductMasterCandidate } from "./types"
+
+export type CreateJanApiClientOptions = {
+  // 明示的に渡された provider を順に試す。env からの自動構築を行う場合は省略。
+  providers?: JanProvider[]
+  // env から provider を自動構築する場合のフォールバック値。
+  // テストコード等から明示的に渡す用。本番は process.env から読む。
+  yahooAppId?: string
+  // ヒットも生成しない最終 stub。fixtures Map を渡せばテストで再現可能。
+  stubFixtures?: Map<string, ProductMasterCandidate>
+}
+
+// providers を未指定で呼ばれた場合、env からプロバイダ chain を構築する:
+//   YAHOO_SHOPPING_APP_ID があれば yahoo → stub
+//   なければ stub のみ (UI からの動作確認・E2E 用)
+export function createJanApiClient(opts: CreateJanApiClientOptions = {}): JanApiClient {
+  const providers = opts.providers ?? buildDefaultProviders(opts)
+
+  return {
+    async lookup(jan: string): Promise<ProductMasterCandidate | null> {
+      // チェックディジット不正は外部 API を叩く前に短絡する。
+      if (!isValidJan(jan)) return null
+
+      for (const provider of providers) {
+        // 早期 return で外部 API 呼び出しを最小化したいので意図的に sequential。
+        // Promise.all で並列実行するとレート制限に当たる確率が上がる。
+        // eslint-disable-next-line no-await-in-loop
+        const hit = await provider.lookup(jan)
+        if (hit) return hit
+      }
+      return null
+    },
+  }
+}
+
+function buildDefaultProviders(opts: CreateJanApiClientOptions): JanProvider[] {
+  const providers: JanProvider[] = []
+
+  const yahooAppId = opts.yahooAppId ?? process.env["YAHOO_SHOPPING_APP_ID"]
+  if (yahooAppId) {
+    providers.push(createYahooProvider({ appId: yahooAppId }))
+  }
+
+  // 最終 stub。fixtures が空なら常に null を返すので副作用なく chain の末尾に置ける。
+  providers.push(createStubProvider({ fixtures: opts.stubFixtures, name: "fallback-stub" }))
+
+  return providers
+}

--- a/packages/jan-api/src/client.ts
+++ b/packages/jan-api/src/client.ts
@@ -3,6 +3,22 @@ import { createStubProvider } from "./providers/stub"
 import { createYahooProvider } from "./providers/yahoo"
 import type { JanApiClient, JanProvider, ProductMasterCandidate } from "./types"
 
+// レイヤ構造（消費者は `JanApiClient` interface だけに依存することを想定）:
+//
+//   consumer (API endpoint / mobile UI)
+//        │  受け取る型は JanApiClient のみ
+//        ▼
+//   JanApiClient   ←  createJanApiClient(opts)
+//        │  内部で chain を順に試して first hit を返す
+//        ▼
+//   JanProvider[]  ←  Yahoo / 楽天 (TBD) / JANCODE (TBD) / stub / ...
+//
+// 上のレイヤは下のレイヤの実体を知らなくて済むので、
+//   - 別 vendor の provider に差し替え (e.g. Rakuten 本実装、staging endpoint, mock)
+//   - client 層の振る舞い変更 (cache, retry, metrics 等の wrapper)
+//   - 消費者側のテスト (custom JanApiClient を直接注入)
+// が独立に行える。
+
 export type CreateJanApiClientOptions = {
   // 明示的に渡された provider を順に試す。env からの自動構築を行う場合は省略。
   providers?: JanProvider[]
@@ -17,7 +33,7 @@ export type CreateJanApiClientOptions = {
 //   YAHOO_SHOPPING_APP_ID があれば yahoo → stub
 //   なければ stub のみ (UI からの動作確認・E2E 用)
 export function createJanApiClient(opts: CreateJanApiClientOptions = {}): JanApiClient {
-  const providers = opts.providers ?? buildDefaultProviders(opts)
+  const providers = opts.providers ?? createDefaultProviders(opts)
 
   return {
     async lookup(jan: string): Promise<ProductMasterCandidate | null> {
@@ -36,7 +52,11 @@ export function createJanApiClient(opts: CreateJanApiClientOptions = {}): JanApi
   }
 }
 
-function buildDefaultProviders(opts: CreateJanApiClientOptions): JanProvider[] {
+// env / opts から「デフォルトの」provider chain を組み立てる convenience helper。
+// 消費者が独自の chain を組みたい場合は呼ばずに、`providers: [...]` を直接渡せばよい。
+// この関数を export しておくのは、デフォルト構成に独自 provider を **追加** する用途
+// (例: stub の前に楽天や JANCODE を挟む) を想定しているため。
+export function createDefaultProviders(opts: CreateJanApiClientOptions = {}): JanProvider[] {
   const providers: JanProvider[] = []
 
   const yahooAppId = opts.yahooAppId ?? process.env["YAHOO_SHOPPING_APP_ID"]

--- a/packages/jan-api/src/index.ts
+++ b/packages/jan-api/src/index.ts
@@ -1,0 +1,11 @@
+export { createJanApiClient, type CreateJanApiClientOptions } from "./client"
+export { computeJanCheckDigit, isValidJan } from "./jan"
+export { createStubProvider, type StubProviderOptions } from "./providers/stub"
+export { createYahooProvider, type YahooFetch, type YahooProviderOptions } from "./providers/yahoo"
+export type {
+  JanApiClient,
+  JanProvider,
+  ProductMasterCandidate,
+  ProductMasterConfidence,
+  ProductMasterSource,
+} from "./types"

--- a/packages/jan-api/src/index.ts
+++ b/packages/jan-api/src/index.ts
@@ -1,4 +1,8 @@
-export { createJanApiClient, type CreateJanApiClientOptions } from "./client"
+export {
+  createDefaultProviders,
+  createJanApiClient,
+  type CreateJanApiClientOptions,
+} from "./client"
 export { computeJanCheckDigit, isValidJan } from "./jan"
 export { createStubProvider, type StubProviderOptions } from "./providers/stub"
 export { createYahooProvider, type YahooFetch, type YahooProviderOptions } from "./providers/yahoo"

--- a/packages/jan-api/src/jan.test.ts
+++ b/packages/jan-api/src/jan.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { computeJanCheckDigit, isValidJan } from "./jan"
+
+test("isValidJan accepts a known-good EAN-13", () => {
+  // 4901234567894 は EAN-13 のサンプルで広く流通している値
+  expect(isValidJan("4901234567894")).toBe(true)
+})
+
+test("isValidJan rejects bad check digit", () => {
+  expect(isValidJan("4901234567890")).toBe(false)
+})
+
+test("isValidJan rejects non-13/8 length", () => {
+  expect(isValidJan("123")).toBe(false)
+  expect(isValidJan("12345678901234")).toBe(false)
+})
+
+test("isValidJan rejects non-digit string", () => {
+  expect(isValidJan("49012abcd5678")).toBe(false)
+})
+
+test("computeJanCheckDigit matches known EAN-13", () => {
+  expect(computeJanCheckDigit("490123456789")).toBe(4)
+})
+
+test("computeJanCheckDigit throws on non-digit input", () => {
+  expect(() => computeJanCheckDigit("abc")).toThrow()
+})

--- a/packages/jan-api/src/jan.ts
+++ b/packages/jan-api/src/jan.ts
@@ -1,0 +1,26 @@
+// EAN-13 / EAN-8 (JAN) のチェックディジット検証。
+// バーコード読取の精度ノイズを早期に弾くために提供する純関数。
+
+const DIGITS_RE = /^\d+$/
+
+export function isValidJan(jan: string): boolean {
+  if (jan.length !== 13 && jan.length !== 8) return false
+  if (!DIGITS_RE.test(jan)) return false
+  return computeJanCheckDigit(jan.slice(0, -1)) === Number(jan.at(-1))
+}
+
+// EAN-13 / EAN-8 共通のチェックディジット算出。
+// 末尾を除いた桁を 3:1 重みで右から交互に乗じ、その合計の 10 補数の下 1 桁。
+//   - 13 桁では右端から (3,1,3,1,3,1,3,1,3,1,3,1) で重み付け
+//   - 8 桁でも同じパターン (右端から 3,1,3,1,3,1,3)
+export function computeJanCheckDigit(prefix: string): number {
+  if (!DIGITS_RE.test(prefix)) {
+    throw new Error("computeJanCheckDigit: prefix must be a digit string")
+  }
+  let sum = 0
+  for (let i = 0; i < prefix.length; i++) {
+    const digit = Number(prefix[prefix.length - 1 - i])
+    sum += i % 2 === 0 ? digit * 3 : digit
+  }
+  return (10 - (sum % 10)) % 10
+}

--- a/packages/jan-api/src/providers/stub.ts
+++ b/packages/jan-api/src/providers/stub.ts
@@ -1,0 +1,19 @@
+import type { JanProvider, ProductMasterCandidate } from "../types"
+
+// テスト・E2E・appid 未設定環境でのフォールバック用に固定値を返す provider。
+// 引数の Map に登録された jan のみ hit させ、それ以外は null を返す。
+
+export type StubProviderOptions = {
+  fixtures?: Map<string, ProductMasterCandidate> | undefined
+  name?: string | undefined
+}
+
+export function createStubProvider(opts: StubProviderOptions = {}): JanProvider {
+  const fixtures = opts.fixtures ?? new Map<string, ProductMasterCandidate>()
+  return {
+    name: opts.name ?? "stub",
+    async lookup(jan) {
+      return fixtures.get(jan) ?? null
+    },
+  }
+}

--- a/packages/jan-api/src/providers/yahoo.test.ts
+++ b/packages/jan-api/src/providers/yahoo.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { createYahooProvider, type YahooFetch } from "./yahoo"
+
+const VALID_JAN = "4901234567894"
+
+const buildFetch = (impl: YahooFetch): YahooFetch => impl
+
+test("createYahooProvider throws when appId is missing", () => {
+  expect(() => createYahooProvider({ appId: "" })).toThrow()
+})
+
+test("Yahoo provider: hit returns ProductMasterCandidate", async () => {
+  const fetchMock = buildFetch(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            hits: [
+              {
+                name: "Test Product",
+                image: { medium: "https://example.test/m.jpg" },
+                brand: { name: "Brand X" },
+                seller: { name: "Mfr Y" },
+              },
+            ],
+          }
+        },
+      }) as Awaited<ReturnType<YahooFetch>>,
+  )
+  const provider = createYahooProvider({ appId: "fake-app-id", fetch: fetchMock })
+
+  const result = await provider.lookup(VALID_JAN)
+  expect(result).not.toBeNull()
+  expect(result?.name).toBe("Test Product")
+  expect(result?.brand).toBe("Brand X")
+  expect(result?.manufacturer).toBe("Mfr Y")
+  expect(result?.imageUrl).toBe("https://example.test/m.jpg")
+  expect(result?.source).toBe("YAHOO_SHOPPING")
+  expect(result?.confidence).toBe("MEDIUM")
+})
+
+test("Yahoo provider: empty hits returns null (cf. 404)", async () => {
+  const fetchMock = buildFetch(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        async json() {
+          return { hits: [] }
+        },
+      }) as Awaited<ReturnType<YahooFetch>>,
+  )
+  const provider = createYahooProvider({ appId: "fake-app-id", fetch: fetchMock })
+
+  expect(await provider.lookup(VALID_JAN)).toBeNull()
+})
+
+test("Yahoo provider: 429 rate limit returns null", async () => {
+  const fetchMock = buildFetch(
+    async () =>
+      ({
+        ok: false,
+        status: 429,
+        async json() {
+          return { error: "rate limit" }
+        },
+      }) as Awaited<ReturnType<YahooFetch>>,
+  )
+  const provider = createYahooProvider({ appId: "fake-app-id", fetch: fetchMock })
+
+  expect(await provider.lookup(VALID_JAN)).toBeNull()
+})
+
+test("Yahoo provider: network error returns null", async () => {
+  const fetchMock = buildFetch(async () => {
+    throw new Error("ECONNRESET")
+  })
+  const provider = createYahooProvider({ appId: "fake-app-id", fetch: fetchMock })
+
+  expect(await provider.lookup(VALID_JAN)).toBeNull()
+})

--- a/packages/jan-api/src/providers/yahoo.test.ts
+++ b/packages/jan-api/src/providers/yahoo.test.ts
@@ -81,3 +81,29 @@ test("Yahoo provider: network error returns null", async () => {
 
   expect(await provider.lookup(VALID_JAN)).toBeNull()
 })
+
+test("Yahoo provider: endpoint / confidence / name are overridable", async () => {
+  let calledUrl = ""
+  const fetchMock = buildFetch(async (url) => {
+    calledUrl = url
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { hits: [{ name: "Mock Product" }] }
+      },
+    } as Awaited<ReturnType<YahooFetch>>
+  })
+  const provider = createYahooProvider({
+    appId: "fake-app-id",
+    endpoint: "https://staging.example.test/itemSearch",
+    confidence: "HIGH",
+    name: "yahoo-staging",
+    fetch: fetchMock,
+  })
+
+  expect(provider.name).toBe("yahoo-staging")
+  const result = await provider.lookup(VALID_JAN)
+  expect(calledUrl.startsWith("https://staging.example.test/itemSearch?")).toBe(true)
+  expect(result?.confidence).toBe("HIGH")
+})

--- a/packages/jan-api/src/providers/yahoo.ts
+++ b/packages/jan-api/src/providers/yahoo.ts
@@ -1,9 +1,9 @@
-import type { JanProvider, ProductMasterCandidate } from "../types"
+import type { JanProvider, ProductMasterCandidate, ProductMasterConfidence } from "../types"
 
 // Yahoo!ショッピング 商品検索 API v3.
 // docs: https://developer.yahoo.co.jp/webapi/shopping/v3/itemsearch.html
 
-const YAHOO_ENDPOINT = "https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch"
+const DEFAULT_YAHOO_ENDPOINT = "https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch"
 
 export type YahooFetch = (
   input: string,
@@ -16,10 +16,19 @@ export type YahooFetch = (
 
 export type YahooProviderOptions = {
   appId: string
+  // テスト・staging・将来のバージョン切替を見据え、endpoint を差し替え可能にしておく。
+  // 未指定なら本番 v3 endpoint。
+  endpoint?: string
   // テスト時に fetch を差し替える穴。本番は global fetch。
   fetch?: YahooFetch
   // 1 回のリクエストの timeout (ms)。デフォルト 5 秒。
   timeoutMs?: number
+  // hit を返したときの confidence。Yahoo は出品ベースなのでデフォルト MEDIUM だが
+  // chain 構成や運用観測に応じて引き上げ/引き下げを許容する。
+  confidence?: ProductMasterConfidence
+  // provider 識別名。複数 Yahoo provider (本番 / staging) を chain に並べる際に
+  // 衝突を避けるため上書き可能。デフォルト "yahoo"。
+  name?: string
 }
 
 // Yahoo の hit レスポンスから必要な欄だけ抽出する。
@@ -41,13 +50,15 @@ export function createYahooProvider(opts: YahooProviderOptions): JanProvider {
   if (!opts.appId) {
     throw new Error("createYahooProvider: appId is required")
   }
+  const endpoint = opts.endpoint ?? DEFAULT_YAHOO_ENDPOINT
   const fetchImpl = opts.fetch ?? (globalThis.fetch as YahooFetch)
   const timeoutMs = opts.timeoutMs ?? 5000
+  const confidence: ProductMasterConfidence = opts.confidence ?? "MEDIUM"
 
   return {
-    name: "yahoo",
+    name: opts.name ?? "yahoo",
     async lookup(jan): Promise<ProductMasterCandidate | null> {
-      const url = `${YAHOO_ENDPOINT}?appid=${encodeURIComponent(opts.appId)}&jan_code=${encodeURIComponent(jan)}&results=1`
+      const url = `${endpoint}?appid=${encodeURIComponent(opts.appId)}&jan_code=${encodeURIComponent(jan)}&results=1`
       const ctrl = new AbortController()
       const timer = setTimeout(() => ctrl.abort(), timeoutMs)
       try {
@@ -70,8 +81,7 @@ export function createYahooProvider(opts: YahooProviderOptions): JanProvider {
           imageUrl: hit.image?.medium ?? hit.image?.small ?? null,
           source: "YAHOO_SHOPPING",
           sourceRaw: hit,
-          // Yahoo は出品ベースなので商品名一致の精度は中程度
-          confidence: "MEDIUM",
+          confidence,
         }
       } catch {
         // ネットワークエラー / abort / parse エラーは null でフォールバック

--- a/packages/jan-api/src/providers/yahoo.ts
+++ b/packages/jan-api/src/providers/yahoo.ts
@@ -1,0 +1,84 @@
+import type { JanProvider, ProductMasterCandidate } from "../types"
+
+// Yahoo!ショッピング 商品検索 API v3.
+// docs: https://developer.yahoo.co.jp/webapi/shopping/v3/itemsearch.html
+
+const YAHOO_ENDPOINT = "https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch"
+
+export type YahooFetch = (
+  input: string,
+  init?: { signal?: AbortSignal },
+) => Promise<{
+  ok: boolean
+  status: number
+  json(): Promise<unknown>
+}>
+
+export type YahooProviderOptions = {
+  appId: string
+  // テスト時に fetch を差し替える穴。本番は global fetch。
+  fetch?: YahooFetch
+  // 1 回のリクエストの timeout (ms)。デフォルト 5 秒。
+  timeoutMs?: number
+}
+
+// Yahoo の hit レスポンスから必要な欄だけ抽出する。
+// API のフル schema を持つのは過剰なので、参照する path だけ optional chaining で読む。
+type YahooHit = {
+  name?: string
+  image?: { medium?: string; small?: string }
+  brand?: { name?: string }
+  seller?: { name?: string }
+  janCode?: string
+  jan_code?: string
+}
+
+type YahooResponse = {
+  hits?: YahooHit[]
+}
+
+export function createYahooProvider(opts: YahooProviderOptions): JanProvider {
+  if (!opts.appId) {
+    throw new Error("createYahooProvider: appId is required")
+  }
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as YahooFetch)
+  const timeoutMs = opts.timeoutMs ?? 5000
+
+  return {
+    name: "yahoo",
+    async lookup(jan): Promise<ProductMasterCandidate | null> {
+      const url = `${YAHOO_ENDPOINT}?appid=${encodeURIComponent(opts.appId)}&jan_code=${encodeURIComponent(jan)}&results=1`
+      const ctrl = new AbortController()
+      const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+      try {
+        const res = await fetchImpl(url, { signal: ctrl.signal })
+        if (!res.ok) {
+          // 429 / 5xx 含めヒット扱いにしない (上位がフォールバックする)
+          return null
+        }
+        const data = (await res.json()) as YahooResponse
+        const hit = data.hits?.[0]
+        if (!hit?.name) return null
+        return {
+          jan,
+          name: hit.name,
+          manufacturer: hit.seller?.name ?? null,
+          brand: hit.brand?.name ?? null,
+          contentAmount: null,
+          contentUnit: null,
+          categoryHint: null,
+          imageUrl: hit.image?.medium ?? hit.image?.small ?? null,
+          source: "YAHOO_SHOPPING",
+          sourceRaw: hit,
+          // Yahoo は出品ベースなので商品名一致の精度は中程度
+          confidence: "MEDIUM",
+        }
+      } catch {
+        // ネットワークエラー / abort / parse エラーは null でフォールバック
+        return null
+      } finally {
+        clearTimeout(timer)
+      }
+    },
+  }
+}

--- a/packages/jan-api/src/types.ts
+++ b/packages/jan-api/src/types.ts
@@ -1,0 +1,42 @@
+// JAN コードから取得した商品メタデータ。
+// `packages/db` の `productMasters` 行 schema から `id` を除いたサブセット相当。
+// DB に persist する直前で `id` / timestamps を付与する。
+
+export type ProductMasterSource =
+  | "YAHOO_SHOPPING"
+  | "RAKUTEN_ICHIBA"
+  | "JANCODE_LOOKUP"
+  | "GS1_JICFS"
+  | "OTHER"
+
+export type ProductMasterConfidence = "HIGH" | "MEDIUM" | "LOW"
+
+export type ProductMasterCandidate = {
+  jan: string
+  name: string
+  manufacturer: string | null
+  brand: string | null
+  contentAmount: number | null
+  contentUnit: string | null
+  categoryHint: string | null
+  imageUrl: string | null
+  source: ProductMasterSource
+  // provider が返した生レスポンス。
+  // DB の sourceRaw に丸ごと突っ込むことで後で別 provider の生データに切替える際の
+  // 検証材料を残す。プロバイダ間で構造が違うので unknown のまま運ぶ。
+  sourceRaw: unknown
+  confidence: ProductMasterConfidence | null
+}
+
+// 各 provider が実装する I/F。null は「ヒットしなかった / 一時的に取得できなかった」。
+// 例外は呼び出し側でハンドルする想定 (再試行 / フォールバック etc.) なので、
+// レート制限等の transient エラーも null で返してフォールバックを促す。
+export type JanProvider = {
+  readonly name: string
+  lookup(jan: string): Promise<ProductMasterCandidate | null>
+}
+
+// 上位 client の I/F。複数 provider を順に試し、最初の hit を返す。
+export type JanApiClient = {
+  lookup(jan: string): Promise<ProductMasterCandidate | null>
+}

--- a/packages/jan-api/tsconfig.json
+++ b/packages/jan-api/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## 概要 / Why

モバイルでカメラ読取した JAN (EAN-13 / 8) を商品メタデータ (`name` / `brand` / `imageUrl` 等) に変換するクライアントを実装。これがないと UC-02「在庫をバーコードで追加」のモバイル側スクリーンが完成しない。

`packages/jan-api` 自体は雛形のみ存在 (空)。本 PR で実装を埋める。

## 変更内容 / What

### 構成
```
packages/jan-api/
├── src/
│   ├── index.ts              # public API
│   ├── client.ts             # createJanApiClient ファクトリ
│   ├── jan.ts                # EAN-13 / 8 チェックディジット検証
│   ├── types.ts              # ProductMasterCandidate / JanProvider
│   └── providers/
│       ├── yahoo.ts          # Yahoo!ショッピング v3 itemSearch
│       └── stub.ts           # 固定 fixtures (テスト + フォールバック)
└── package.json / tsconfig.json
```

### 振る舞い
- `createJanApiClient({ providers? | yahooAppId? | stubFixtures? })` で client 構築
- `client.lookup(jan)` は順に provider を試し **first hit を即 return**（rate limit を増幅させないため sequential は意図的）
- 不正 JAN（チェックディジット不一致 / 桁数違い）は外部 API 呼び出し前に短絡で null
- Yahoo provider:
  - hit → `MEDIUM` confidence の `ProductMasterCandidate`
  - empty hits / 4xx / 429 / 5xx / network error / timeout 5s → null
  - `fetch` 注入可能（テスト用）
- env `YAHOO_SHOPPING_APP_ID` 未設定なら自動 chain は stub のみ

### `ProductMasterCandidate`
`packages/db` の `productMasters` 行から `id` / timestamps を除いたサブセット。`source: ProductMasterSource` enum と `confidence` を含む。`sourceRaw` に provider が返した生レスポンスを `unknown` のまま運ぶ（後で別 provider 切替時の検証材料）。

### Unit test (16 case)
- JAN check digit: known-good / bad / wrong length / non-digit / known reference value / throw on bad input
- Yahoo provider: appId 必須 / hit / empty hits / 429 / network error
- Client chain: invalid JAN 短絡 / first hit wins / null fallthrough / 全 null / env auto chain で stub fallback

## 設計判断

- **Yahoo を一次採用、stub をフォールバック末尾に配置**。楽天 / JANCODE は本 PR ではスキップ（要件は MVP で Yahoo + stub）
- **ProductMaster の DB 保存は本 PR ではしない**。`lookup()` はリードオンリー副作用なしで UI からの preview 表示にも直接呼べる粒度。persist は後続 #75 (barcode → items find-or-create) で扱う
- **transient エラー (429/5xx/timeout) も null** で返してフォールバックを促す。throw すると上位 client が結果を拾えない
- **`no-await-in-loop` lint を 1 行 disable**: 並列実行はレート制限増幅の温床なので意図的に sequential

## スコープ外 / Out of scope

- ProductMaster の DB 保存 (#75)
- バーコード経由の Item find-or-create endpoint (#75)
- 楽天 / JANCODE provider 本実装
- mobile からの直接呼び出しか API 経由かの判断

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/jan-api typecheck`
- [x] `bun --filter '*' typecheck` (全パッケージ green)
- [x] `bun --filter @prep-hamster/jan-api test` → 16 pass / 0 fail
- [x] `bun x oxlint packages/jan-api/src` → 0 errors
- [x] `bun x oxfmt --check packages/jan-api/src` → ok

## 関連 Issue / Links

- Closes #74
- Base: #82 (#71 items CRUD)
- 設計参考: `docs/flow/v1.0.0/jan-api-candidates.md`

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない