### PR TITLE
feat(api): add POST /v1/items/by-barcode (find-or-create)

### DIFF
--- a/apps/core/api/e2e/items-by-barcode.test.ts
+++ b/apps/core/api/e2e/items-by-barcode.test.ts
@@ -1,0 +1,192 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { items, productMasters } from "@prep-hamster/db"
+import type { JanApiClient, ProductMasterCandidate } from "@prep-hamster/jan-api"
+import { createApp } from "../src/app"
+import { seedGroupWithMembership, seedItem, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+const VALID_JAN = "4901234567894"
+
+const stubJanApi = (candidate: ProductMasterCandidate | null): JanApiClient => ({
+  async lookup() {
+    return candidate
+  },
+})
+
+const sampleCandidate = (
+  overrides: Partial<ProductMasterCandidate> = {},
+): ProductMasterCandidate => ({
+  jan: VALID_JAN,
+  name: "テスト商品",
+  manufacturer: "Test Mfr",
+  brand: "Test Brand",
+  contentAmount: null,
+  contentUnit: null,
+  categoryHint: null,
+  imageUrl: "https://example.test/img.jpg",
+  source: "YAHOO_SHOPPING",
+  sourceRaw: { stub: true },
+  confidence: "MEDIUM",
+  ...overrides,
+})
+
+test("POST /v1/items/by-barcode by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb, janApi: stubJanApi(sampleCandidate()) })
+  const res = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})
+
+test("POST /v1/items/by-barcode existing item returns 200 productLookup=existing", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const itemId = await seedItem(groupId, "Pre-existing")
+  await testDb.update(items).set({ barcode: VALID_JAN }).where(eq(items.id, itemId))
+
+  let lookupCalls = 0
+  const janApi: JanApiClient = {
+    async lookup() {
+      lookupCalls++
+      return null
+    },
+  }
+  const app = createApp({ db: testDb, janApi })
+  const res = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as {
+    item: { id: string; name: string }
+    productLookup: string
+  }
+  expect(body.productLookup).toBe("existing")
+  expect(body.item.id).toBe(itemId)
+  expect(body.item.name).toBe("Pre-existing")
+  // 既存ヒットでは外部 API を叩かない
+  expect(lookupCalls).toBe(0)
+})
+
+test("POST /v1/items/by-barcode lookup hit creates productMaster + item", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb, janApi: stubJanApi(sampleCandidate()) })
+  const res = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as {
+    item: { id: string; name: string; productMasterId: string | null; manufacturer: string | null }
+    productMaster: { id: string; jan: string; source: string } | null
+    productLookup: string
+  }
+  expect(body.productLookup).toBe("hit")
+  expect(body.item.name).toBe("テスト商品")
+  expect(body.item.manufacturer).toBe("Test Mfr")
+  expect(body.item.productMasterId).not.toBeNull()
+  expect(body.productMaster?.jan).toBe(VALID_JAN)
+  expect(body.productMaster?.source).toBe("YAHOO_SHOPPING")
+
+  const [pmRow] = await testDb
+    .select()
+    .from(productMasters)
+    .where(eq(productMasters.jan, VALID_JAN))
+  expect(pmRow).toBeDefined()
+})
+
+test("POST /v1/items/by-barcode lookup miss creates placeholder item", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb, janApi: stubJanApi(null) })
+  const res = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as {
+    item: { name: string; productMasterId: string | null; barcode: string | null }
+    productMaster: unknown
+    productLookup: string
+  }
+  expect(body.productLookup).toBe("miss")
+  // placeholder の name は barcode をそのまま使う
+  expect(body.item.name).toBe(VALID_JAN)
+  expect(body.item.barcode).toBe(VALID_JAN)
+  expect(body.item.productMasterId).toBeNull()
+  expect(body.productMaster).toBeNull()
+})
+
+test("POST /v1/items/by-barcode hit then existing returns 200 with productMaster preserved", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb, janApi: stubJanApi(sampleCandidate()) })
+  // 1 回目: hit で作成
+  const first = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+  expect(first.status).toBe(201)
+
+  // 2 回目: 既存 hit で再利用 (200)
+  const second = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+  expect(second.status).toBe(200)
+  const body = (await second.json()) as {
+    productLookup: string
+    productMaster: { jan: string } | null
+  }
+  expect(body.productLookup).toBe("existing")
+  // 既存 item に productMasterId が紐付いていれば response に productMaster が乗る
+  expect(body.productMaster?.jan).toBe(VALID_JAN)
+})
+
+test("POST /v1/items/by-barcode by non-member returns 403 FORBIDDEN_GROUP_ACCESS", async () => {
+  const ownerId = await seedUser("Owner")
+  const outsiderId = await seedUser("Outsider")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+
+  const app = createApp({ db: testDb, janApi: stubJanApi(null) })
+  const res = await app.request("/v1/items/by-barcode", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": outsiderId },
+    body: JSON.stringify({ groupId, barcode: VALID_JAN }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
+})

--- a/apps/core/api/package.json
+++ b/apps/core/api/package.json
@@ -29,6 +29,7 @@
     "@hono/zod-openapi": "^0.19.10",
     "@hono/zod-validator": "^0.4.0",
     "@prep-hamster/db": "workspace:*",
+    "@prep-hamster/jan-api": "workspace:*",
     "@prep-hamster/schema": "workspace:*",
     "@scalar/hono-api-reference": "^0.10.13",
     "drizzle-orm": "^0.41.0",

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
 import { Scalar } from "@scalar/hono-api-reference"
 import type { Db } from "@prep-hamster/db"
+import { createJanApiClient, type JanApiClient } from "@prep-hamster/jan-api"
 import { withUserAuth } from "./middleware/auth"
 import { withDb } from "./middleware/db"
 import { onError } from "./middleware/error"
@@ -14,14 +15,27 @@ export type AppEnv = {
   Variables: {
     db: Db
     userId: string
+    janApi: JanApiClient
   }
 }
 
-export function createApp(opts: { db: Db }) {
+export type CreateAppOptions = {
+  db: Db
+  // 消費者は JanApiClient interface のみに依存。
+  // 未指定なら env (YAHOO_SHOPPING_APP_ID) ベースの default chain を使う。
+  janApi?: JanApiClient
+}
+
+export function createApp(opts: CreateAppOptions) {
   const app = new OpenAPIHono<AppEnv>()
+  const janApi = opts.janApi ?? createJanApiClient()
 
   app.onError(onError)
   app.use("*", withDb(opts.db))
+  app.use("*", async (c, next) => {
+    c.set("janApi", janApi)
+    await next()
+  })
   app.use("/v1/*", withUserAuth)
 
   app.doc("/openapi.json", {

--- a/apps/core/api/src/routes/items.ts
+++ b/apps/core/api/src/routes/items.ts
@@ -1,12 +1,15 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { and, asc, eq, isNull } from "drizzle-orm"
-import { categories, items, stocks } from "@prep-hamster/db"
+import { categories, items, productMasters, stocks } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
 import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
 import {
   createItemBodyDtoSchema,
   errorResponseSchema,
+  itemByBarcodeBodyDtoSchema,
+  itemByBarcodeResponseDtoSchema,
   itemDtoSchema,
+  productMasterDtoSchema,
   updateItemBodyDtoSchema,
 } from "./schemas"
 
@@ -21,6 +24,26 @@ const ListQuerySchema = z.object({
   groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
   categoryId: z.string().uuid().optional(),
   barcode: z.string().optional(),
+})
+
+const toProductMasterDto = (
+  row: typeof productMasters.$inferSelect,
+): z.infer<typeof productMasterDtoSchema> => ({
+  id: row.id,
+  jan: row.jan,
+  name: row.name,
+  manufacturer: row.manufacturer,
+  brand: row.brand,
+  contentAmount: row.contentAmount,
+  contentUnit: row.contentUnit,
+  categoryHint: row.categoryHint,
+  imageUrl: row.imageUrl,
+  source: row.source,
+  confidence: row.confidence,
+  fetchedAt: row.fetchedAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
 })
 
 const toItemDto = (row: typeof items.$inferSelect): z.infer<typeof itemDtoSchema> => ({
@@ -76,6 +99,19 @@ const BARCODE_DUPLICATE_RESPONSE = {
     message: "同じ group に同じ barcode の item が既に存在します",
   },
 } as const
+
+async function loadProductMaster(
+  db: AppEnv["Variables"]["db"],
+  productMasterId: string,
+): Promise<typeof productMasters.$inferSelect | null> {
+  const [row] = await db
+    .select()
+    .from(productMasters)
+    .where(and(eq(productMasters.id, productMasterId), isNull(productMasters.deletedAt)))
+    .limit(1)
+  return row ?? null
+}
+
 
 // 同じ groupId + barcode の active item が既にいないか確認する。
 // DB 側にも `(group_id, barcode) WHERE product_master_id IS NULL AND barcode IS NOT NULL`
@@ -218,6 +254,42 @@ const patchItemRoute = createRoute({
     },
     422: {
       description: "ボディ不正 / barcode 重複 / category 不整合",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const itemByBarcodeRoute = createRoute({
+  method: "post",
+  path: "/by-barcode",
+  tags: ["items"],
+  summary: "barcode から item を find-or-create (EDITOR 以上)",
+  request: {
+    body: { content: { "application/json": { schema: itemByBarcodeBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "既存 item を返却",
+      content: {
+        "application/json": { schema: itemByBarcodeResponseDtoSchema },
+      },
+    },
+    201: {
+      description: "外部 lookup hit / miss いずれかで新規作成",
+      content: {
+        "application/json": { schema: itemByBarcodeResponseDtoSchema },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -445,4 +517,147 @@ export const itemsRouter = new OpenAPIHono<AppEnv>()
       .where(and(eq(items.id, id), isNull(items.deletedAt)))
 
     return c.body(null, 204)
+  })
+  .openapi(itemByBarcodeRoute, async (c) => {
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+    const janApi = c.get("janApi")
+
+    const access = await checkGroupAccess(db, userId, body.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    // 1. 既存 item 検索: 同じ group + barcode で active な item があれば再利用。
+    //    productMasterId の有無は問わない (手動入力 / バーコード経路の両方を拾う)。
+    const [existingItem] = await db
+      .select()
+      .from(items)
+      .where(
+        and(
+          eq(items.groupId, body.groupId),
+          eq(items.barcode, body.barcode),
+          isNull(items.deletedAt),
+        ),
+      )
+      .limit(1)
+
+    if (existingItem) {
+      const productMaster = existingItem.productMasterId
+        ? await loadProductMaster(db, existingItem.productMasterId)
+        : null
+      return c.json(
+        {
+          item: toItemDto(existingItem),
+          productMaster: productMaster ? toProductMasterDto(productMaster) : null,
+          productLookup: "existing" as const,
+        },
+        200,
+      )
+    }
+
+    // 2. 外部 lookup。null ならフォールバック (placeholder で進む)。
+    const candidate = await janApi.lookup(body.barcode)
+
+    if (!candidate) {
+      const [created] = await db
+        .insert(items)
+        .values({
+          id: crypto.randomUUID(),
+          groupId: body.groupId,
+          productMasterId: null,
+          // 外部 lookup miss 時は barcode をそのまま name に置く placeholder。
+          // ユーザーが後で PATCH で書き換える前提。
+          name: body.barcode,
+          barcode: body.barcode,
+          categoryId: null,
+          defaultUnit: null,
+          manufacturer: null,
+          memo: null,
+        })
+        .returning()
+      if (!created) {
+        throw new Error("item insert (placeholder) returned no row")
+      }
+      return c.json(
+        {
+          item: toItemDto(created),
+          productMaster: null,
+          productLookup: "miss" as const,
+        },
+        201,
+      )
+    }
+
+    // 3. lookup hit: productMaster を upsert (jan UNIQUE) してから item insert。
+    //    同じ JAN を別 group が先に登録していれば既存 master を再利用する。
+    //    fetchedAt と confidence / 各メタは最新 lookup 結果で更新する。
+    const [pm] = await db
+      .insert(productMasters)
+      .values({
+        id: crypto.randomUUID(),
+        jan: candidate.jan,
+        name: candidate.name,
+        manufacturer: candidate.manufacturer,
+        brand: candidate.brand,
+        contentAmount: candidate.contentAmount,
+        contentUnit: candidate.contentUnit,
+        categoryHint: candidate.categoryHint,
+        imageUrl: candidate.imageUrl,
+        source: candidate.source,
+        sourceRaw: candidate.sourceRaw,
+        confidence: candidate.confidence,
+        fetchedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: productMasters.jan,
+        set: {
+          name: candidate.name,
+          manufacturer: candidate.manufacturer,
+          brand: candidate.brand,
+          contentAmount: candidate.contentAmount,
+          contentUnit: candidate.contentUnit,
+          categoryHint: candidate.categoryHint,
+          imageUrl: candidate.imageUrl,
+          source: candidate.source,
+          sourceRaw: candidate.sourceRaw,
+          confidence: candidate.confidence,
+          fetchedAt: new Date(),
+          updatedAt: new Date(),
+        },
+      })
+      .returning()
+    if (!pm) {
+      throw new Error("productMaster upsert returned no row")
+    }
+
+    const [createdItem] = await db
+      .insert(items)
+      .values({
+        id: crypto.randomUUID(),
+        groupId: body.groupId,
+        productMasterId: pm.id,
+        // item の name / manufacturer は productMaster からコピーして group 内で
+        // 上書き可能にする (data-model.md 準拠: items はプロジェクト内の overrides 層)。
+        name: candidate.name,
+        barcode: body.barcode,
+        categoryId: null,
+        defaultUnit: null,
+        manufacturer: candidate.manufacturer,
+        memo: null,
+      })
+      .returning()
+    if (!createdItem) {
+      throw new Error("item insert (hit) returned no row")
+    }
+
+    return c.json(
+      {
+        item: toItemDto(createdItem),
+        productMaster: toProductMasterDto(pm),
+        productLookup: "hit" as const,
+      },
+      201,
+    )
   })

--- a/apps/core/api/src/routes/items.ts
+++ b/apps/core/api/src/routes/items.ts
@@ -112,7 +112,6 @@ async function loadProductMaster(
   return row ?? null
 }
 
-
 // 同じ groupId + barcode の active item が既にいないか確認する。
 // DB 側にも `(group_id, barcode) WHERE product_master_id IS NULL AND barcode IS NOT NULL`
 // の uniqueIndex があるが、明示的に事前 check してわかりやすい 422 を返す。

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -152,8 +152,8 @@ export const itemByBarcodeBodyDtoSchema = z
 
 export const itemByBarcodeResponseDtoSchema = z
   .object({
-    item: z.lazy(() => itemDtoSchema),
-    productMaster: z.lazy(() => productMasterDtoSchema).nullable(),
+    item: itemDtoSchema,
+    productMaster: productMasterDtoSchema.nullable(),
     productLookup: z.enum(["existing", "hit", "miss"]),
   })
   .openapi("ItemByBarcodeResponse")

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -123,6 +123,41 @@ export const itemDtoSchema = z
   })
   .openapi("Item")
 
+export const productMasterDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    jan: z.string(),
+    name: z.string(),
+    manufacturer: z.string().nullable(),
+    brand: z.string().nullable(),
+    contentAmount: z.number().nullable(),
+    contentUnit: z.string().nullable(),
+    categoryHint: z.string().nullable(),
+    imageUrl: z.string().nullable(),
+    source: z.enum(["YAHOO_SHOPPING", "RAKUTEN_ICHIBA", "JANCODE_LOOKUP", "GS1_JICFS", "OTHER"]),
+    confidence: z.enum(["HIGH", "MEDIUM", "LOW"]).nullable(),
+    fetchedAt: z.string().datetime({ offset: true }),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("ProductMaster")
+
+export const itemByBarcodeBodyDtoSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    barcode: z.string().min(1).max(64),
+  })
+  .openapi("ItemByBarcodeBody")
+
+export const itemByBarcodeResponseDtoSchema = z
+  .object({
+    item: z.lazy(() => itemDtoSchema),
+    productMaster: z.lazy(() => productMasterDtoSchema).nullable(),
+    productLookup: z.enum(["existing", "hit", "miss"]),
+  })
+  .openapi("ItemByBarcodeResponse")
+
 // 手動入力では productMasterId は指定不可（バーコード経路で別途自動紐付け）
 export const createItemBodyDtoSchema = z
   .object({

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@hono/zod-openapi": "^0.19.10",
         "@hono/zod-validator": "^0.4.0",
         "@prep-hamster/db": "workspace:*",
+        "@prep-hamster/jan-api": "workspace:*",
         "@prep-hamster/schema": "workspace:*",
         "@scalar/hono-api-reference": "^0.10.13",
         "drizzle-orm": "^0.41.0",


### PR DESCRIPTION
## 概要 / Why

モバイル MVP（#76 / #77）でカメラスキャン → そのまま在庫追加するフローを成立させるため、JAN コードを起点に **items 行を見つけて無ければ作る** API を追加する。

## 変更内容 / What

### Endpoint
- `POST /v1/items/by-barcode`
- Body: `{ groupId: UUID, barcode: string }`
- Auth: EDITOR 以上（find-or-create なので create 権限が要る）

### 処理フロー
1. 同 group + barcode で active な item を検索 → ヒットすれば 200 `productLookup="existing"`、productMasterId があれば response に `productMaster` 同梱
2. 無ければ `janApi.lookup(barcode)` で外部 lookup
3. **hit**: `productMaster` を `jan` UNIQUE で upsert → item insert（productMasterId 紐付け、name/manufacturer は candidate からコピー）→ 201 `productLookup="hit"`
4. **miss**: barcode を name に置く placeholder item を作成 → 201 `productLookup="miss"`、`productMaster` は null

レスポンス:
```ts
{
  item: ItemDto,
  productMaster: ProductMasterDto | null,
  productLookup: "existing" | "hit" | "miss"
}
```

### 主な変更
- `app.ts`: `createApp({ db, janApi? })` で `JanApiClient` を注入可能に。未指定なら env ベースの default chain (`createJanApiClient()`)。**消費者 (この endpoint) は `JanApiClient` interface のみに依存** することを徹底
- `routes/items.ts`: 新 endpoint + `loadProductMaster` / `toProductMasterDto` ヘルパ
- `routes/schemas.ts`: `productMasterDtoSchema` + `itemByBarcodeBodyDtoSchema` + `itemByBarcodeResponseDtoSchema`
- `apps/core/api/package.json`: `@prep-hamster/jan-api` workspace 依存を追加
- `e2e/items-by-barcode.test.ts` 6 case:
  - 認可: VIEWER → 403 INSUFFICIENT_ROLE / 非 member → 403 FORBIDDEN_GROUP_ACCESS
  - existing 再利用 (外部 API 呼ばないことも検証)
  - hit: productMaster + item 作成
  - miss: placeholder item 作成 (name = barcode)
  - hit → 既存 productMaster ありの再ヒットでも `productMaster` が response に乗る

## 設計判断

- **productMaster の上書きポリシー**: `onConflictDoUpdate` で常に最新 lookup 結果に置き換える（v1.0.0）。HIGH → LOW 退化を防ぐ等のロジックは後続で追加余地
- **item の name / manufacturer**: hit 時は productMaster からコピー。group 内 override 想定（data-model.md 準拠）
- **role**: find-only でも EDITOR+ 必須。理由は通常フロー（バーコード → 在庫追加）が必ず create を伴うため。VIEWER の純粋な lookup は `GET /v1/items?barcode=...` を使う
- **不正 JAN**: jan-api 側で短絡されて null（miss 扱い）。placeholder が作られるので user が PATCH で修正可能

## スコープ外 / Out of scope

- バッチ系（複数 barcode 同時登録）
- ユーザー手動の name 上書き UI（モバイル側「場所/期限入力」画面で別途）
- ProductMaster 重複正規化（同 JAN を別 provider で取って整合させる等）
- HIGH/LOW 退化を防ぐ confidence-aware merge

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/api typecheck`
- [x] `bun --filter @prep-hamster/api test:e2e` → 53 pass / 0 fail (うち 6 が #75)
- [x] `bun x oxlint` → 0 errors
- [x] `bun x oxfmt --check` → ok

## 関連 Issue / Links

- Closes #75
- Base: #83 (#74 jan-api package)
- Depends on: #71 (#82) items CRUD、#74 (#83) jan-api、#69 (#80) group authorization

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない