### PR TITLE
feat(mobile): 在庫追加 vertical slice (camera + details + save)

### DIFF
--- a/apps/user/client/mobile/app.json
+++ b/apps/user/client/mobile/app.json
@@ -18,7 +18,15 @@
       "bundler": "metro",
       "output": "static"
     },
-    "plugins": ["expo-router"],
+    "plugins": [
+      "expo-router",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "JAN コードを読み取って商品を登録するためにカメラを使用します"
+        }
+      ]
+    ],
     "experiments": {
       "typedRoutes": true
     }

--- a/apps/user/client/mobile/app/(tabs)/add.tsx
+++ b/apps/user/client/mobile/app/(tabs)/add.tsx
@@ -1,25 +1,38 @@
-import { StyleSheet, Text, View } from "react-native"
+import { router } from "expo-router"
+import { Pressable, StyleSheet, Text, View } from "react-native"
 
-// 在庫追加導線 placeholder。
-// バーコードスキャン → 場所/期限入力の本実装は #77 で行う。
+// 在庫追加のエントリポイント。
+// カメラ起動 / 手動入力 (debug) のいずれかへ進む。
+// 実機では基本カメラ、Simulator やテストでは手動入力で同じ後続フローに乗せる。
 
-export default function AddStock() {
+export default function AddEntry() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>在庫追加 (bootstrap)</Text>
-      <Text style={styles.subtitle}>バーコード読取 / 手動入力は #77 で実装予定</Text>
+      <Pressable style={styles.primary} onPress={() => router.push("/add/scan")}>
+        <Text style={styles.primaryLabel}>カメラで読み取る</Text>
+      </Pressable>
+      <Pressable style={styles.secondary} onPress={() => router.push("/add/manual")}>
+        <Text style={styles.secondaryLabel}>手動で barcode を入力 (debug)</Text>
+      </Pressable>
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  container: { flex: 1, padding: 24, gap: 16, justifyContent: "center" },
+  primary: {
+    backgroundColor: "#2c7be5",
+    borderRadius: 12,
+    paddingVertical: 16,
     alignItems: "center",
-    justifyContent: "center",
-    padding: 16,
-    gap: 8,
   },
-  title: { fontSize: 20, fontWeight: "600" },
-  subtitle: { fontSize: 14, color: "#555" },
+  primaryLabel: { color: "#fff", fontSize: 16, fontWeight: "600" },
+  secondary: {
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#aaa",
+  },
+  secondaryLabel: { color: "#333", fontSize: 14 },
 })

--- a/apps/user/client/mobile/app/(tabs)/index.tsx
+++ b/apps/user/client/mobile/app/(tabs)/index.tsx
@@ -1,40 +1,76 @@
-import { StyleSheet, Text, View } from "react-native"
-import { useHealth } from "@/use-health"
+import { useFocusEffect } from "expo-router"
+import { useCallback } from "react"
+import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, Text, View } from "react-native"
+import { useStocks, type StockListItem } from "@/use-stocks"
 
-// 在庫一覧 placeholder。
-// 本実装は別 Issue (#77 + 後続) で stocks endpoint を叩いて表示する。
-// bootstrap (#76) の段階では /v1/health の結果を出して API 疎通を確認するだけ。
+// 在庫一覧画面 (/(tabs)/index)。
+// 追加画面 (#77) からの導線で「保存後に一覧に反映」を満たすためのシンプル表示。
 
 export default function StocksIndex() {
-  const health = useHealth()
+  const { state, reload } = useStocks()
+
+  // tab に戻ってくるたびに最新化したい (#77 の add fl ow からの帰還で表示更新)
+  useFocusEffect(
+    useCallback(() => {
+      reload()
+    }, [reload]),
+  )
+
+  if (state.status === "loading") {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+  if (state.status === "error") {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>取得失敗: {state.message}</Text>
+      </View>
+    )
+  }
+  if (state.rows.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.empty}>在庫はまだありません</Text>
+        <Text style={styles.empty}>「追加」タブから登録してください</Text>
+      </View>
+    )
+  }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>在庫一覧 (bootstrap)</Text>
-      <Text style={styles.subtitle}>API 疎通: {renderHealth(health)}</Text>
+    <FlatList
+      data={state.rows}
+      keyExtractor={(row) => row.id}
+      contentContainerStyle={styles.listContent}
+      refreshControl={<RefreshControl refreshing={false} onRefresh={reload} />}
+      renderItem={({ item }) => <StockRow row={item} />}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+    />
+  )
+}
+
+function StockRow({ row }: { row: StockListItem }) {
+  const expiry = row.useByDate ?? row.bestBeforeDate
+  return (
+    <View style={styles.row}>
+      <Text style={styles.itemName}>{row.itemName}</Text>
+      <Text style={styles.meta}>
+        {row.locationName} ・ {row.quantity} {row.unit}
+        {expiry ? ` ・ 期限 ${expiry}` : ""}
+      </Text>
     </View>
   )
 }
 
-function renderHealth(health: ReturnType<typeof useHealth>): string {
-  switch (health.status) {
-    case "loading":
-      return "確認中..."
-    case "ok":
-      return `OK (HTTP ${health.httpStatus})`
-    case "error":
-      return `NG (${health.message})`
-  }
-}
-
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 16,
-    gap: 8,
-  },
-  title: { fontSize: 20, fontWeight: "600" },
-  subtitle: { fontSize: 14, color: "#555" },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, gap: 6 },
+  empty: { color: "#666" },
+  error: { color: "#c0392b" },
+  listContent: { paddingVertical: 8 },
+  row: { paddingHorizontal: 16, paddingVertical: 12, gap: 4 },
+  itemName: { fontSize: 16, fontWeight: "600" },
+  meta: { fontSize: 13, color: "#555" },
+  separator: { height: 1, backgroundColor: "#eee" },
 })

--- a/apps/user/client/mobile/app/add/_layout.tsx
+++ b/apps/user/client/mobile/app/add/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from "expo-router"
+
+// /add/* のサブスタック。タブの上に push されてヘッダ + 戻るが付く。
+export default function AddStackLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="scan" options={{ title: "バーコードを読む" }} />
+      <Stack.Screen name="manual" options={{ title: "手動入力" }} />
+      <Stack.Screen name="details" options={{ title: "詳細を入力" }} />
+    </Stack>
+  )
+}

--- a/apps/user/client/mobile/app/add/details.tsx
+++ b/apps/user/client/mobile/app/add/details.tsx
@@ -1,0 +1,387 @@
+import DateTimePicker, { type DateTimePickerEvent } from "@react-native-community/datetimepicker"
+import { router, useLocalSearchParams } from "expo-router"
+import { useEffect, useState } from "react"
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native"
+import { getApiClient } from "@/api"
+import { getCurrentGroupId } from "@/config"
+
+// 詳細入力 + 保存画面。
+// 受け取る params:
+//   - itemId       : POST /v1/items/by-barcode で確定した item の UUID
+//   - productLookup: "existing" | "hit" | "miss"
+//                     miss なら item.name を編集する UI を出す。
+//
+// 保存フロー:
+//   1. (productLookup === miss && name 編集あり) PATCH /v1/items/:id
+//   2. POST /v1/stocks
+//   3. 成功で /(tabs) に replace し、一覧画面で最新化
+
+type ItemDto = {
+  id: string
+  name: string
+  manufacturer: string | null
+}
+
+type LocationDto = {
+  id: string
+  name: string
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ok"; item: ItemDto; locations: LocationDto[] }
+  | { status: "error"; message: string }
+
+export default function AddDetailsScreen() {
+  const params = useLocalSearchParams<{ itemId: string; productLookup: string }>()
+  const itemId = params.itemId
+  const productLookup = params.productLookup as "existing" | "hit" | "miss" | undefined
+
+  const [load, setLoad] = useState<LoadState>({ status: "loading" })
+  const [name, setName] = useState("")
+  const [locationId, setLocationId] = useState<string | null>(null)
+  const [quantity, setQuantity] = useState("1")
+  const [unit, setUnit] = useState("個")
+  const [useByDate, setUseByDate] = useState<Date | null>(null)
+  const [bestBeforeDate, setBestBeforeDate] = useState<Date | null>(null)
+  const [note, setNote] = useState("")
+  const [showUseBy, setShowUseBy] = useState(false)
+  const [showBestBefore, setShowBestBefore] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!itemId) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const client = getApiClient()
+        const groupId = getCurrentGroupId()
+        const [itemRes, locsRes] = await Promise.all([
+          client.v1.items[":id"].$get({ param: { id: itemId } }),
+          client.v1.locations.$get({ query: { groupId } }),
+        ])
+        if (cancelled) return
+        if (!itemRes.ok) {
+          setLoad({ status: "error", message: `item HTTP ${itemRes.status}` })
+          return
+        }
+        if (!locsRes.ok) {
+          setLoad({ status: "error", message: `locations HTTP ${locsRes.status}` })
+          return
+        }
+        const itemBody = (await itemRes.json()).item
+        const locsBody = (await locsRes.json()).locations
+        setName(itemBody.name)
+        if (locsBody[0]) setLocationId(locsBody[0].id)
+        setLoad({ status: "ok", item: itemBody, locations: locsBody })
+      } catch (err) {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : "unknown"
+        setLoad({ status: "error", message })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [itemId])
+
+  if (!itemId) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>itemId が指定されていません</Text>
+      </View>
+    )
+  }
+  if (load.status === "loading") {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+  if (load.status === "error") {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>取得失敗: {load.message}</Text>
+      </View>
+    )
+  }
+
+  const canEditName = productLookup === "miss"
+  const groupId = getCurrentGroupId()
+
+  async function onSave() {
+    if (!locationId) {
+      setSaveError("場所を選択してください")
+      return
+    }
+    const parsedQty = Number(quantity)
+    if (!Number.isFinite(parsedQty) || parsedQty < 0) {
+      setSaveError("数量は 0 以上の数値で入力してください")
+      return
+    }
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const client = getApiClient()
+      // miss の場合のみ name を更新する (hit / existing は外部 lookup or 既存値を尊重)
+      if (canEditName && load.status === "ok" && name !== load.item.name) {
+        const patchRes = await client.v1.items[":id"].$patch({
+          param: { id: itemId },
+          json: { name },
+        })
+        if (!patchRes.ok) {
+          setSaveError(`item PATCH HTTP ${patchRes.status}`)
+          setSaving(false)
+          return
+        }
+      }
+      const stockRes = await client.v1.stocks.$post({
+        json: {
+          groupId,
+          itemId,
+          locationId,
+          quantity: parsedQty,
+          unit,
+          useByDate: useByDate ? toIsoDate(useByDate) : null,
+          bestBeforeDate: bestBeforeDate ? toIsoDate(bestBeforeDate) : null,
+          openedAt: null,
+          note: note.length > 0 ? note : null,
+        },
+      })
+      if (!stockRes.ok) {
+        setSaveError(`stock POST HTTP ${stockRes.status}`)
+        setSaving(false)
+        return
+      }
+      // 一覧に戻ると useFocusEffect で reload される
+      router.replace("/(tabs)")
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown"
+      setSaveError(message)
+      setSaving(false)
+    }
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+      <Section title={`商品 (${labelForLookup(productLookup)})`}>
+        {canEditName ? (
+          <TextInput value={name} onChangeText={setName} style={styles.input} />
+        ) : (
+          <Text style={styles.staticText}>{name}</Text>
+        )}
+      </Section>
+
+      <Section title="保管場所">
+        {load.locations.length === 0 ? (
+          <Text style={styles.empty}>
+            場所がまだありません。先に /v1/locations で作成してください。
+          </Text>
+        ) : (
+          <View style={styles.choices}>
+            {load.locations.map((loc) => (
+              <Pressable
+                key={loc.id}
+                onPress={() => setLocationId(loc.id)}
+                style={[styles.choice, locationId === loc.id && styles.choiceSelected]}
+              >
+                <Text
+                  style={[styles.choiceLabel, locationId === loc.id && styles.choiceLabelSelected]}
+                >
+                  {loc.name}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        )}
+      </Section>
+
+      <Section title="数量 / 単位">
+        <View style={styles.row}>
+          <TextInput
+            value={quantity}
+            onChangeText={setQuantity}
+            keyboardType="decimal-pad"
+            style={[styles.input, styles.qtyInput]}
+          />
+          <TextInput value={unit} onChangeText={setUnit} style={[styles.input, styles.unitInput]} />
+        </View>
+      </Section>
+
+      <Section title="期限">
+        <DateRow
+          label="使用期限 (useByDate)"
+          value={useByDate}
+          show={showUseBy}
+          setShow={setShowUseBy}
+          setValue={setUseByDate}
+        />
+        <DateRow
+          label="賞味期限 (bestBeforeDate)"
+          value={bestBeforeDate}
+          show={showBestBefore}
+          setShow={setShowBestBefore}
+          setValue={setBestBeforeDate}
+        />
+      </Section>
+
+      <Section title="メモ (任意)">
+        <TextInput
+          value={note}
+          onChangeText={setNote}
+          multiline
+          style={[styles.input, styles.note]}
+        />
+      </Section>
+
+      {saveError ? <Text style={styles.error}>{saveError}</Text> : null}
+
+      <Pressable
+        style={[styles.primary, saving && styles.primaryDisabled]}
+        onPress={onSave}
+        disabled={saving}
+      >
+        {saving ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.primaryLabel}>保存</Text>
+        )}
+      </Pressable>
+    </ScrollView>
+  )
+}
+
+function labelForLookup(lookup: string | undefined): string {
+  switch (lookup) {
+    case "existing":
+      return "既存"
+    case "hit":
+      return "外部 hit"
+    case "miss":
+      return "未登録 (要編集)"
+    default:
+      return "?"
+  }
+}
+
+function toIsoDate(d: Date): string {
+  // YYYY-MM-DD のみ。ローカル日付として扱う。
+  const yyyy = d.getFullYear().toString().padStart(4, "0")
+  const mm = (d.getMonth() + 1).toString().padStart(2, "0")
+  const dd = d.getDate().toString().padStart(2, "0")
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  )
+}
+
+function DateRow({
+  label,
+  value,
+  show,
+  setShow,
+  setValue,
+}: {
+  label: string
+  value: Date | null
+  show: boolean
+  setShow: (v: boolean) => void
+  setValue: (d: Date | null) => void
+}) {
+  function onChange(_e: DateTimePickerEvent, selected: Date | undefined) {
+    // Android はピッカーがモーダルなので選択 / 取消後に閉じる
+    if (Platform.OS !== "ios") setShow(false)
+    if (selected) setValue(selected)
+  }
+
+  return (
+    <View style={styles.dateRow}>
+      <Text style={styles.dateLabel}>{label}</Text>
+      <View style={styles.dateControls}>
+        <Pressable style={styles.dateButton} onPress={() => setShow(true)}>
+          <Text style={styles.dateButtonText}>{value ? toIsoDate(value) : "選択"}</Text>
+        </Pressable>
+        {value ? (
+          <Pressable style={styles.clearButton} onPress={() => setValue(null)}>
+            <Text style={styles.clearButtonText}>クリア</Text>
+          </Pressable>
+        ) : null}
+      </View>
+      {show ? <DateTimePicker value={value ?? new Date()} mode="date" onChange={onChange} /> : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, gap: 16 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16 },
+  section: { gap: 8 },
+  sectionTitle: { fontSize: 14, fontWeight: "600", color: "#333" },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  staticText: { fontSize: 15, paddingVertical: 8 },
+  row: { flexDirection: "row", gap: 8 },
+  qtyInput: { flex: 1 },
+  unitInput: { width: 80 },
+  note: { minHeight: 80, textAlignVertical: "top" },
+  choices: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  choice: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#aaa",
+  },
+  choiceSelected: { backgroundColor: "#2c7be5", borderColor: "#2c7be5" },
+  choiceLabel: { fontSize: 13, color: "#333" },
+  choiceLabelSelected: { color: "#fff", fontWeight: "600" },
+  empty: { color: "#666", fontSize: 13 },
+  error: { color: "#c0392b" },
+  dateRow: { gap: 6 },
+  dateLabel: { fontSize: 13, color: "#444" },
+  dateControls: { flexDirection: "row", gap: 8, alignItems: "center" },
+  dateButton: {
+    borderWidth: 1,
+    borderColor: "#aaa",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    minWidth: 140,
+    alignItems: "center",
+  },
+  dateButtonText: { fontSize: 14 },
+  clearButton: { paddingHorizontal: 8, paddingVertical: 8 },
+  clearButtonText: { color: "#888", fontSize: 13 },
+  primary: {
+    backgroundColor: "#2c7be5",
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  primaryDisabled: { opacity: 0.5 },
+  primaryLabel: { color: "#fff", fontSize: 16, fontWeight: "600" },
+})

--- a/apps/user/client/mobile/app/add/manual.tsx
+++ b/apps/user/client/mobile/app/add/manual.tsx
@@ -1,0 +1,73 @@
+import { router } from "expo-router"
+import { useState } from "react"
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native"
+import { useByBarcode } from "@/use-by-barcode"
+
+// Simulator やカメラが使えない開発環境向けの debug 入口。
+// scan.tsx と同じ後続フロー (詳細画面 → 保存) に乗せる。
+
+export default function ManualBarcodeScreen() {
+  const [barcode, setBarcode] = useState("")
+  const { state, submit } = useByBarcode()
+
+  async function onSubmit() {
+    if (!barcode) return
+    const result = await submit(barcode)
+    if (result) {
+      router.replace({
+        pathname: "/add/details",
+        params: { itemId: result.itemId, productLookup: result.productLookup },
+      })
+    }
+  }
+
+  const submitting = state.status === "loading"
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>JAN コード (EAN-13 / EAN-8)</Text>
+      <TextInput
+        value={barcode}
+        onChangeText={setBarcode}
+        keyboardType="number-pad"
+        placeholder="4901234567894"
+        style={styles.input}
+        editable={!submitting}
+      />
+      {state.status === "error" ? <Text style={styles.error}>{state.message}</Text> : null}
+      <Pressable
+        style={[styles.primary, (!barcode || submitting) && styles.primaryDisabled]}
+        onPress={onSubmit}
+        disabled={!barcode || submitting}
+      >
+        {submitting ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.primaryLabel}>送信</Text>
+        )}
+      </Pressable>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 12 },
+  label: { fontSize: 14, color: "#444" },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  error: { color: "#c0392b" },
+  primary: {
+    backgroundColor: "#2c7be5",
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  primaryDisabled: { opacity: 0.5 },
+  primaryLabel: { color: "#fff", fontSize: 16, fontWeight: "600" },
+})

--- a/apps/user/client/mobile/app/add/scan.tsx
+++ b/apps/user/client/mobile/app/add/scan.tsx
@@ -1,0 +1,95 @@
+import { CameraView, useCameraPermissions } from "expo-camera"
+import { router } from "expo-router"
+import { useRef, useState } from "react"
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native"
+import { useByBarcode } from "@/use-by-barcode"
+
+// カメラスキャン画面。EAN-13 / EAN-8 を読み取って /v1/items/by-barcode に投げる。
+// バーコード読取完了 → 詳細画面に push。
+
+export default function ScanScreen() {
+  const [permission, requestPermission] = useCameraPermissions()
+  const { state, submit } = useByBarcode()
+  const [scannedOnce, setScannedOnce] = useState(false)
+  // CameraView は連続で onBarcodeScanned を発火するので 1 回だけ拾う lock を持つ。
+  const lockRef = useRef(false)
+
+  if (!permission) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.message}>カメラの利用許可が必要です</Text>
+        <Pressable style={styles.primary} onPress={requestPermission}>
+          <Text style={styles.primaryLabel}>許可する</Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.cameraContainer}>
+      <CameraView
+        style={styles.camera}
+        facing="back"
+        barcodeScannerSettings={{ barcodeTypes: ["ean13", "ean8"] }}
+        onBarcodeScanned={async ({ data }) => {
+          if (lockRef.current) return
+          lockRef.current = true
+          setScannedOnce(true)
+          const result = await submit(data)
+          if (result) {
+            router.replace({
+              pathname: "/add/details",
+              params: { itemId: result.itemId, productLookup: result.productLookup },
+            })
+          } else {
+            // submit 失敗時はもう一度スキャン可能にする
+            lockRef.current = false
+          }
+        }}
+      />
+      <View style={styles.overlay}>
+        {state.status === "loading" || scannedOnce ? (
+          <Text style={styles.overlayText}>商品を確認しています...</Text>
+        ) : (
+          <Text style={styles.overlayText}>JAN コードに枠を合わせてください</Text>
+        )}
+        {state.status === "error" ? <Text style={styles.overlayError}>{state.message}</Text> : null}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  cameraContainer: { flex: 1 },
+  camera: { flex: 1 },
+  overlay: {
+    position: "absolute",
+    bottom: 32,
+    left: 16,
+    right: 16,
+    padding: 12,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    borderRadius: 12,
+    alignItems: "center",
+    gap: 4,
+  },
+  overlayText: { color: "#fff" },
+  overlayError: { color: "#ff8a80" },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, gap: 12 },
+  message: { fontSize: 14, color: "#333" },
+  primary: {
+    backgroundColor: "#2c7be5",
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+  },
+  primaryLabel: { color: "#fff", fontWeight: "600" },
+})

--- a/apps/user/client/mobile/expo-env.d.ts
+++ b/apps/user/client/mobile/expo-env.d.ts
@@ -6,5 +6,6 @@ declare namespace NodeJS {
   interface ProcessEnv {
     EXPO_PUBLIC_API_BASE_URL?: string
     EXPO_PUBLIC_STUB_USER_ID?: string
+    EXPO_PUBLIC_STUB_GROUP_ID?: string
   }
 }

--- a/apps/user/client/mobile/package.json
+++ b/apps/user/client/mobile/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "@prep-hamster/api-client": "workspace:*",
+    "@prep-hamster/jan-api": "workspace:*",
+    "@react-native-community/datetimepicker": "8.2.0",
     "expo": "~52.0.27",
+    "expo-camera": "~16.0.10",
     "expo-constants": "~17.0.4",
     "expo-linking": "~7.0.4",
     "expo-router": "~4.0.17",

--- a/apps/user/client/mobile/src/config.ts
+++ b/apps/user/client/mobile/src/config.ts
@@ -1,0 +1,11 @@
+// v1.0.0 のスタブ設定。
+// 認証は #76 の auth.ts に分離。ここでは認証以外の「現在のコンテキスト」値
+// (groupId 等) を集約する。Supabase Auth + group switcher 実装時にこの 1 箇所を
+// 置き換えれば足りるよう interface を絞る。
+
+const FALLBACK_GROUP_ID = "00000000-0000-0000-0000-000000000010"
+
+// API 側に seed しておいた group の UUID を env で渡す。未設定時は fallback。
+export function getCurrentGroupId(): string {
+  return process.env.EXPO_PUBLIC_STUB_GROUP_ID ?? FALLBACK_GROUP_ID
+}

--- a/apps/user/client/mobile/src/use-by-barcode.ts
+++ b/apps/user/client/mobile/src/use-by-barcode.ts
@@ -1,0 +1,49 @@
+import { useState } from "react"
+import { getApiClient } from "./api"
+import { getCurrentGroupId } from "./config"
+
+// POST /v1/items/by-barcode を叩く submit hook。
+// scan / manual 両方の入口から同じ後続フロー (詳細画面 → 保存) に乗せる。
+
+export type ByBarcodeResult = {
+  itemId: string
+  productLookup: "existing" | "hit" | "miss"
+}
+
+type State = { status: "idle" } | { status: "loading" } | { status: "error"; message: string }
+
+export function useByBarcode(): {
+  state: State
+  submit: (barcode: string) => Promise<ByBarcodeResult | null>
+  reset: () => void
+} {
+  const [state, setState] = useState<State>({ status: "idle" })
+
+  async function submit(barcode: string): Promise<ByBarcodeResult | null> {
+    setState({ status: "loading" })
+    try {
+      const client = getApiClient()
+      const groupId = getCurrentGroupId()
+      const res = await client.v1.items["by-barcode"].$post({
+        json: { groupId, barcode },
+      })
+      if (!res.ok) {
+        setState({ status: "error", message: `HTTP ${res.status}` })
+        return null
+      }
+      const body = await res.json()
+      setState({ status: "idle" })
+      return { itemId: body.item.id, productLookup: body.productLookup }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown"
+      setState({ status: "error", message })
+      return null
+    }
+  }
+
+  function reset() {
+    setState({ status: "idle" })
+  }
+
+  return { state, submit, reset }
+}

--- a/apps/user/client/mobile/src/use-stocks.ts
+++ b/apps/user/client/mobile/src/use-stocks.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react"
+import { getApiClient } from "./api"
+import { getCurrentGroupId } from "./config"
+
+// 在庫一覧 + アイテム / 場所マスタを並行取得して、画面表示用に join したデータを返す。
+// react-query は依存追加を増やすので useState/useEffect の最小構成で。
+// 規模が増えたら別途 issue で react-query 導入を検討。
+
+export type StockListItem = {
+  id: string
+  itemName: string
+  locationName: string
+  quantity: number
+  unit: string
+  useByDate: string | null
+  bestBeforeDate: string | null
+}
+
+type State =
+  | { status: "loading" }
+  | { status: "ok"; rows: StockListItem[] }
+  | { status: "error"; message: string }
+
+export function useStocks(): { state: State; reload: () => void } {
+  const [state, setState] = useState<State>({ status: "loading" })
+  const [reloadKey, setReloadKey] = useState(0)
+  const reload = useCallback(() => setReloadKey((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const client = getApiClient()
+        const groupId = getCurrentGroupId()
+        const [stocksRes, itemsRes, locationsRes] = await Promise.all([
+          client.v1.stocks.$get({ query: { groupId } }),
+          client.v1.items.$get({ query: { groupId } }),
+          client.v1.locations.$get({ query: { groupId } }),
+        ])
+        if (cancelled) return
+        if (!stocksRes.ok) {
+          setState({ status: "error", message: `stocks HTTP ${stocksRes.status}` })
+          return
+        }
+        if (!itemsRes.ok) {
+          setState({ status: "error", message: `items HTTP ${itemsRes.status}` })
+          return
+        }
+        if (!locationsRes.ok) {
+          setState({ status: "error", message: `locations HTTP ${locationsRes.status}` })
+          return
+        }
+
+        const stocks = (await stocksRes.json()).stocks
+        const items = (await itemsRes.json()).items
+        const locations = (await locationsRes.json()).locations
+
+        const itemMap = new Map(items.map((i) => [i.id, i.name]))
+        const locMap = new Map(locations.map((l) => [l.id, l.name]))
+
+        const rows: StockListItem[] = stocks.map((s) => ({
+          id: s.id,
+          itemName: itemMap.get(s.itemId) ?? "(unknown item)",
+          locationName: locMap.get(s.locationId) ?? "(unknown location)",
+          quantity: s.quantity,
+          unit: s.unit,
+          useByDate: s.useByDate,
+          bestBeforeDate: s.bestBeforeDate,
+        }))
+        setState({ status: "ok", rows })
+      } catch (err) {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : "unknown"
+        setState({ status: "error", message })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [reloadKey])
+
+  return { state, reload }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@prep-hamster/api-client": "workspace:*",
+        "@prep-hamster/jan-api": "workspace:*",
+        "@react-native-community/datetimepicker": "8.2.0",
         "expo": "~52.0.27",
+        "expo-camera": "~16.0.10",
         "expo-constants": "~17.0.4",
         "expo-linking": "~7.0.4",
         "expo-router": "~4.0.17",
@@ -631,6 +634,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
 
+    "@react-native-community/datetimepicker": ["@react-native-community/datetimepicker@8.2.0", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": ">=50.0.0", "react": "*", "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["expo", "react-native-windows"] }, "sha512-qrUPhiBvKGuG9Y+vOqsc56RPFcHa1SU2qbAMT0hfGkoFIj3FodE0VuPVrEa8fgy7kcD5NQmkZIKgHOBLV0+hWg=="],
+
     "@react-native/assets-registry": ["@react-native/assets-registry@0.76.5", "", {}, "sha512-MN5dasWo37MirVcKWuysRkRr4BjNc81SXwUtJYstwbn8oEkfnwR9DaqdDTo/hHOnTdhafffLIa2xOOHcjDIGEw=="],
 
     "@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.76.9", "", { "dependencies": { "@react-native/codegen": "0.76.9" } }, "sha512-vxL/vtDEIYHfWKm5oTaEmwcnNGsua/i9OjIxBDBFiJDu5i5RU3bpmDiXQm/bJxrJNPRp5lW0I0kpGihVhnMAIQ=="],
@@ -1038,6 +1043,8 @@
     "expo": ["expo@52.0.49", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "0.22.28", "@expo/config": "~10.0.11", "@expo/config-plugins": "~9.0.17", "@expo/fingerprint": "0.11.11", "@expo/metro-config": "0.19.12", "@expo/vector-icons": "~14.0.4", "babel-preset-expo": "~12.0.12", "expo-asset": "~11.0.5", "expo-constants": "~17.0.8", "expo-file-system": "~18.0.12", "expo-font": "~13.0.4", "expo-keep-awake": "~14.0.3", "expo-modules-autolinking": "2.0.8", "expo-modules-core": "2.2.3", "fbemitter": "^3.0.0", "web-streams-polyfill": "^3.3.2", "whatwg-url-without-unicode": "8.0.0-3" }, "peerDependencies": { "@expo/dom-webview": "*", "@expo/metro-runtime": "*", "react": "*", "react-native": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/dom-webview", "@expo/metro-runtime", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-ge3gUnuyGEePWWKzPY7TQ7FsvtFTdmsdYDHeBVUjMr9KIoQig/gf8A03oH26p3UtTL6sUJcyOIg9vwIHGNPSUw=="],
 
     "expo-asset": ["expo-asset@11.0.5", "", { "dependencies": { "@expo/image-utils": "^0.6.5", "expo-constants": "~17.0.8", "invariant": "^2.2.4", "md5-file": "^3.2.3" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-TL60LmMBGVzs3NQcO8ylWqBumMh4sx0lmeJsn7+9C88fylGDhyyVnKZ1PyTXo9CVDBkndutZx2JUEQWM9BaiXw=="],
+
+    "expo-camera": ["expo-camera@16.0.18", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-NP5u2yyc+wZc9GdUXH+jcEytyXZwBnHxItMwXoZQQxi4wgltwvs4XfSWjBtRZe1LngnhpBfPyPJV0aShjWlLDg=="],
 
     "expo-constants": ["expo-constants@17.0.8", "", { "dependencies": { "@expo/config": "~10.0.11", "@expo/env": "~0.4.2" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg=="],
 


### PR DESCRIPTION
## 概要 / Why

2026-05-05 ピボットで決まった v1.0.0 モバイル MVP の本丸。**カメラ → JAN 読取 → アイテム特定 → 場所/期限入力 → 保存 → 一覧反映** を成立させる。

## 変更内容 / What

### 依存追加
- `expo-camera` (~16.0.10) — `CameraView` + barcode scanning
- `@react-native-community/datetimepicker` (8.2.0) — 期限入力用

### 新規ファイル
- `src/config.ts`: `getCurrentGroupId()` stub (env: `EXPO_PUBLIC_STUB_GROUP_ID`)。Supabase Auth + group switcher 導入時の差し替えポイント
- `src/use-stocks.ts`: stocks / items / locations を並行取得して join（react-query は導入せず useState/useEffect のみ）
- `src/use-by-barcode.ts`: `POST /v1/items/by-barcode` の submit hook。scan / manual の両入口で共有

### 画面
| Path | 役割 |
| --- | --- |
| `(tabs)/index.tsx` | 在庫一覧（空 / loading / error / pull-to-refresh、`useFocusEffect` で再読込） |
| `(tabs)/add.tsx` | エントリ: カメラボタン / 手動入力ボタン |
| `add/scan.tsx` | カメラ。`CameraView` で EAN-13/8 を読取、二重発火を ref lock で抑制 |
| `add/manual.tsx` | Simulator / カメラ非搭載端末向け debug 入口（barcode を typing） |
| `add/details.tsx` | item 名 (miss 時のみ編集可) / 場所 chips / qty・unit / useByDate・bestBeforeDate / note → PATCH item (miss 時) → POST /v1/stocks → 一覧 replace |

### app.json
- `expo-camera` plugin 登録、permission 文言を日本語化

## 設計判断

- **scan / manual で共通の後続 (details) に乗せる**: シミュレータでも動かしたいので debug 経路を本流に組み込む（Issue メモにある「カメラが使えない端末向けに JAN 手入力 debug 入口を 1 つ」）
- **state は useState/useEffect**: react-query は依存追加が大きく v1.0.0 ではオーバースペック。規模が増えたら別途 Issue で導入検討
- **保存後の一覧反映**: `useFocusEffect` でタブ復帰時に再 fetch。WebSocket / push subscription は v1.1.0
- **name 編集は productLookup === "miss" のみ**: hit / existing は productMaster の信頼を優先（手動上書きは別途 PATCH で）
- **画面遷移は `router.replace`**: scan → details で「戻る」が camera に戻ってしまうのを避けるため details では replace 経由

## スコープ外 / Out of scope

- 在庫の消費 / 移動 UI → v1.1.0 (#72 後)
- 検索 / フィルタ UI → v1.1.0 (#73)
- グループ管理 UI → v1.1.0
- Push 通知 → v1.1.0
- 自動 E2E (Detox / Mobile Playwright) → v1.1.0
- 写真撮影での item 登録 → 将来

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/mobile typecheck` → green
- [x] `bun x oxlint apps/user/client/mobile` → 0 errors
- [x] `bun x oxfmt --check apps/user/client/mobile` → ok
- [ ] **手動確認 (PR レビュー時 / merge 前)**:
  - [ ] iOS Simulator で `/add/manual` から JAN 入力 → /add/details → 保存 → 一覧反映
  - [ ] 実機 (Expo Go) で `/add/scan` のカメラ permission → 実バーコード読取 → 同フロー
  - [ ] 場所が seed されていない group で「場所がまだありません」表示

> Note: 自動 E2E は v1.1.0 で Detox 導入予定。本 PR では実機での主要パスを手動確認することが merge 条件。

## 関連 Issue / Links

- Closes #77
- Base: #85 (#76 mobile bootstrap)
- Depends on: #67 (#79), #69 (#80), #70 (#81), #71 (#82), #74 (#83), #75 (#84)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck）が通っている
- [x] スコープ外の変更を含めていない