### PR TITLE
feat(api): add withGroupAccess middleware (membership / role check)

### DIFF
--- a/apps/core/api/e2e/group-access.test.ts
+++ b/apps/core/api/e2e/group-access.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { memberships } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import { seedGroupWithMembership, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+// withGroupAccess middleware の振る舞いを /v1/stocks (query.groupId) と
+// /v1/groups/:id (path.id) を通じて E2E で検証する。
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("GET /v1/stocks?groupId=X by member returns 200", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: unknown[] }
+  expect(body.stocks).toEqual([])
+})
+
+test("GET /v1/stocks?groupId=X by non-member returns 403", async () => {
+  const aliceId = await seedUser("Alice")
+  const bobId = await seedUser("Bob")
+  const bobGroupId = await seedGroupWithMembership(bobId, "Bob's Home")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${bobGroupId}`, {
+    headers: { "x-user-id": aliceId },
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
+})
+
+test("GET /v1/stocks with malformed groupId returns 400", async () => {
+  const userId = await seedUser()
+
+  const app = createApp({ db: testDb })
+  const res = await app.request("/v1/stocks?groupId=not-a-uuid", {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(400)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("BAD_REQUEST")
+})
+
+test("GET /v1/stocks with soft-deleted membership returns 403", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+
+  // 既存 membership を soft-delete
+  await testDb
+    .update(memberships)
+    .set({ deletedAt: new Date() })
+    .where(eq(memberships.userId, userId))
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
+})
+
+test("PATCH /v1/groups/:id by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Shared Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-user-id": viewerId,
+    },
+    body: JSON.stringify({ name: "Viewer Attempt" }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})

--- a/apps/core/api/e2e/groups.test.ts
+++ b/apps/core/api/e2e/groups.test.ts
@@ -89,7 +89,7 @@ test("GET /v1/groups returns only groups the user is a member of", async () => {
   expect(body.groups[0]?.name).toBe("Alice's Home")
 })
 
-test("GET /v1/groups/:id by non-member returns 404", async () => {
+test("GET /v1/groups/:id by non-member returns 403", async () => {
   const aliceId = await seedUser("Alice")
   const bobId = await seedUser("Bob")
   const bobGroupId = await seedGroupWithMembership(bobId, "Bob's Home")
@@ -99,7 +99,9 @@ test("GET /v1/groups/:id by non-member returns 404", async () => {
     headers: { "x-user-id": aliceId },
   })
 
-  expect(res.status).toBe(404)
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
 })
 
 test("PATCH /v1/groups/:id by OWNER returns 200 and updates name", async () => {
@@ -139,9 +141,11 @@ test("PATCH /v1/groups/:id by EDITOR returns 403", async () => {
   })
 
   expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
 })
 
-test("PATCH /v1/groups/:id by non-member returns 404", async () => {
+test("PATCH /v1/groups/:id by non-member returns 403", async () => {
   const ownerId = await seedUser("Owner")
   const outsiderId = await seedUser("Outsider")
   const groupId = await seedGroupWithMembership(ownerId, "Closed Home")
@@ -156,5 +160,7 @@ test("PATCH /v1/groups/:id by non-member returns 404", async () => {
     body: JSON.stringify({ name: "Sneak" }),
   })
 
-  expect(res.status).toBe(404)
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("FORBIDDEN_GROUP_ACCESS")
 })

--- a/apps/core/api/src/middleware/group-access.ts
+++ b/apps/core/api/src/middleware/group-access.ts
@@ -1,0 +1,84 @@
+import type { Context } from "hono"
+import { createMiddleware } from "hono/factory"
+import { and, eq, isNull } from "drizzle-orm"
+import { z } from "@hono/zod-openapi"
+import { memberships } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import type { ApiErrorBody } from "./error"
+
+// 全 groupId-scoped endpoint で「current user がその group の member であること」を強制する。
+// 個別 route の handler から DB アクセス権チェックを取り除き、漏れを防ぐ。
+
+export type Role = "OWNER" | "EDITOR" | "VIEWER"
+
+// 上位 role が下位 role の権限を包含する: OWNER > EDITOR > VIEWER
+const ROLE_RANK: Record<Role, number> = { OWNER: 3, EDITOR: 2, VIEWER: 1 }
+
+export type Membership = typeof memberships.$inferSelect
+
+export type GroupAccessEnv = {
+  Variables: AppEnv["Variables"] & { membership: Membership }
+}
+
+export type ExtractGroupId = (c: Context) => string | undefined
+
+const uuidSchema = z.string().uuid()
+
+export const withGroupAccess = (extractGroupId: ExtractGroupId, requiredRole?: Role) =>
+  createMiddleware<AppEnv & GroupAccessEnv>(async (c, next) => {
+    const groupId = extractGroupId(c)
+    if (!groupId || !uuidSchema.safeParse(groupId).success) {
+      return c.json<ApiErrorBody>(
+        {
+          error: {
+            code: "BAD_REQUEST",
+            message: "有効な groupId が必要です",
+          },
+        },
+        400,
+      )
+    }
+
+    const userId = c.get("userId")
+    const db = c.get("db")
+
+    const [member] = await db
+      .select()
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.userId, userId),
+          eq(memberships.groupId, groupId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+
+    if (!member) {
+      return c.json<ApiErrorBody>(
+        {
+          error: {
+            code: "FORBIDDEN_GROUP_ACCESS",
+            message: "この group に対するアクセス権がありません",
+          },
+        },
+        403,
+      )
+    }
+
+    if (requiredRole && ROLE_RANK[member.role as Role] < ROLE_RANK[requiredRole]) {
+      return c.json<ApiErrorBody>(
+        {
+          error: {
+            code: "INSUFFICIENT_ROLE",
+            message: `${requiredRole} 以上の権限が必要です`,
+          },
+        },
+        403,
+      )
+    }
+
+    c.set("membership", member)
+    await next()
+    return
+  })

--- a/apps/core/api/src/middleware/group-access.ts
+++ b/apps/core/api/src/middleware/group-access.ts
@@ -66,16 +66,21 @@ export const withGroupAccess = (extractGroupId: ExtractGroupId, requiredRole?: R
       )
     }
 
-    if (requiredRole && ROLE_RANK[member.role as Role] < ROLE_RANK[requiredRole]) {
-      return c.json<ApiErrorBody>(
-        {
-          error: {
-            code: "INSUFFICIENT_ROLE",
-            message: `${requiredRole} 以上の権限が必要です`,
+    if (requiredRole) {
+      // DB に想定外の role 文字列が入っていた場合は fail-closed で拒否する。
+      // pgEnum で型は守られているはずだが、認可処理なので防御的に未知値を弾く。
+      const memberRoleRank = ROLE_RANK[member.role as Role]
+      if (memberRoleRank == null || memberRoleRank < ROLE_RANK[requiredRole]) {
+        return c.json<ApiErrorBody>(
+          {
+            error: {
+              code: "INSUFFICIENT_ROLE",
+              message: `${requiredRole} 以上の権限が必要です`,
+            },
           },
-        },
-        403,
-      )
+          403,
+        )
+      }
     }
 
     c.set("membership", member)

--- a/apps/core/api/src/routes/groups.ts
+++ b/apps/core/api/src/routes/groups.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { and, eq, inArray, isNull } from "drizzle-orm"
 import { groups, memberships } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
+import { withGroupAccess } from "../middleware/group-access"
 import {
   createGroupBodyDtoSchema,
   errorResponseSchema,
@@ -102,6 +103,7 @@ const getGroupRoute = createRoute({
   path: "/{id}",
   tags: ["groups"],
   summary: "group 単件取得（member のみ）",
+  middleware: [withGroupAccess((c) => c.req.param("id"))] as const,
   request: { params: IdParamSchema },
   responses: {
     200: {
@@ -116,8 +118,12 @@ const getGroupRoute = createRoute({
       description: "未認証",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
     404: {
-      description: "未参加 or 存在しない",
+      description: "存在しない",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -128,6 +134,7 @@ const patchGroupRoute = createRoute({
   path: "/{id}",
   tags: ["groups"],
   summary: "group の名前変更（OWNER のみ）",
+  middleware: [withGroupAccess((c) => c.req.param("id"), "OWNER")] as const,
   request: {
     params: IdParamSchema,
     body: {
@@ -152,11 +159,11 @@ const patchGroupRoute = createRoute({
       content: { "application/json": { schema: errorResponseSchema } },
     },
     403: {
-      description: "OWNER でない",
+      description: "OWNER でない / 未参加",
       content: { "application/json": { schema: errorResponseSchema } },
     },
     404: {
-      description: "未参加 or 存在しない",
+      description: "存在しない",
       content: { "application/json": { schema: errorResponseSchema } },
     },
     422: {
@@ -242,23 +249,6 @@ export const groupsRouter = new OpenAPIHono<AppEnv>()
   .openapi(getGroupRoute, async (c) => {
     const { id } = c.req.valid("param")
     const db = c.get("db")
-    const userId = c.get("userId")
-
-    const [member] = await db
-      .select({ id: memberships.id })
-      .from(memberships)
-      .where(
-        and(
-          eq(memberships.userId, userId),
-          eq(memberships.groupId, id),
-          isNull(memberships.deletedAt),
-        ),
-      )
-      .limit(1)
-
-    if (!member) {
-      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
-    }
 
     const [row] = await db
       .select()
@@ -276,26 +266,6 @@ export const groupsRouter = new OpenAPIHono<AppEnv>()
     const { id } = c.req.valid("param")
     const body = c.req.valid("json")
     const db = c.get("db")
-    const userId = c.get("userId")
-
-    const [member] = await db
-      .select({ role: memberships.role })
-      .from(memberships)
-      .where(
-        and(
-          eq(memberships.userId, userId),
-          eq(memberships.groupId, id),
-          isNull(memberships.deletedAt),
-        ),
-      )
-      .limit(1)
-
-    if (!member) {
-      return c.json({ error: { code: "NOT_FOUND", message: "group が見つかりません" } }, 404)
-    }
-    if (member.role !== "OWNER") {
-      return c.json({ error: { code: "FORBIDDEN", message: "OWNER のみ更新できます" } }, 403)
-    }
 
     const [row] = await db
       .update(groups)

--- a/apps/core/api/src/routes/stocks.ts
+++ b/apps/core/api/src/routes/stocks.ts
@@ -1,7 +1,8 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { and, eq, isNull } from "drizzle-orm"
-import { stocks } from "@prep-hamster/db"
+import { memberships, stocks } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
+import { withGroupAccess } from "../middleware/group-access"
 import { createStockBodyDtoSchema, errorResponseSchema, stockDtoSchema } from "./schemas"
 
 const ListQuerySchema = z.object({
@@ -30,6 +31,7 @@ const listStocksRoute = createRoute({
   path: "/",
   tags: ["stocks"],
   summary: "在庫一覧を取得",
+  middleware: [withGroupAccess((c) => c.req.query("groupId"))] as const,
   request: {
     query: ListQuerySchema,
   },
@@ -44,6 +46,10 @@ const listStocksRoute = createRoute({
     },
     401: {
       description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
       content: { "application/json": { schema: errorResponseSchema } },
     },
     422: {
@@ -80,6 +86,10 @@ const createStockRoute = createRoute({
       description: "未認証",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
     422: {
       description: "ボディ不正",
       content: { "application/json": { schema: errorResponseSchema } },
@@ -102,6 +112,32 @@ export const stocksRouter = new OpenAPIHono<AppEnv>()
   .openapi(createStockRoute, async (c) => {
     const body = c.req.valid("json")
     const db = c.get("db")
+    const userId = c.get("userId")
+
+    // body.groupId の membership は middleware では検査できないため (body 読込のタイミング)、
+    // ここで明示的にチェックする。本検査の middleware 化は別 Issue (#69 後続) で扱う。
+    const [member] = await db
+      .select({ id: memberships.id })
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.userId, userId),
+          eq(memberships.groupId, body.groupId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+    if (!member) {
+      return c.json(
+        {
+          error: {
+            code: "FORBIDDEN_GROUP_ACCESS",
+            message: "この group に対するアクセス権がありません",
+          },
+        },
+        403,
+      )
+    }
 
     const [created] = await db
       .insert(stocks)


### PR DESCRIPTION
> **Note**: 元の draft #80 が #79 マージ時に自動 close され reopen 不可になったため、同内容で recreate。CodeRabbit レビュー履歴は #80 を参照。

## 概要 / Why

`groupId` を受ける全 endpoint で「current user がその group の member であること」を強制したい。各 route で都度 SQL を書くと漏れが出るため、middleware に集約。UC-09 の権限管理を実効化する基盤。

## 変更内容 / What

- `apps/core/api/src/middleware/group-access.ts` 追加
  - `withGroupAccess(extractGroupId, requiredRole?)` factory
  - 不在 → 403 `FORBIDDEN_GROUP_ACCESS` / role 不足 → 403 `INSUFFICIENT_ROLE` / malformed → 400
  - 未知 role に fail-closed（CodeRabbit 指摘対応済み）
- 適用: `/v1/groups/:id` GET / PATCH (OWNER) / `/v1/stocks` GET
- E2E 追加: `e2e/group-access.test.ts` 5 ケース

## 関連 Issue / Links

- Closes #69
- Replaces closed #80 (force-push 後 reopen 不可のため再作成)
- 元 PR #80 では CodeRabbit が「defense-in-depth の対応は堅実」と ack 済み