### PR TITLE
feat(api): expand /v1/stocks lifecycle (consume/discard/move/soft-delete)

### DIFF
--- a/apps/core/api/e2e/stocks-lifecycle.test.ts
+++ b/apps/core/api/e2e/stocks-lifecycle.test.ts
@@ -1,0 +1,252 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { and, eq } from "drizzle-orm"
+import { stockEvents, stocks } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import {
+  seedGroupWithMembership,
+  seedItem,
+  seedLocation,
+  seedMembership,
+  seedStock,
+  seedUser,
+} from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+async function setupGroupWithStock(quantity = 10) {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Home")
+  const locationId = await seedLocation(groupId, "Pantry")
+  const itemId = await seedItem(groupId, "Apple")
+  const stockId = await seedStock(groupId, itemId, locationId, quantity)
+  return { userId, groupId, locationId, itemId, stockId }
+}
+
+test("POST /v1/stocks/:id/consume reduces quantity + records CONSUME event", async () => {
+  const { userId, stockId, groupId } = await setupGroupWithStock(10)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/consume`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantityDelta: 3, reason: "lunch" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as {
+    stock: { quantity: number }
+    event: { eventType: string; quantityDelta: number; reason: string | null }
+  }
+  expect(body.stock.quantity).toBe(7)
+  expect(body.event.eventType).toBe("CONSUME")
+  expect(body.event.quantityDelta).toBe(-3)
+  expect(body.event.reason).toBe("lunch")
+
+  const events = await testDb.select().from(stockEvents).where(eq(stockEvents.stockId, stockId))
+  expect(events).toHaveLength(1)
+  expect(events[0]?.groupId).toBe(groupId)
+})
+
+test("POST /v1/stocks/:id/consume rejects when result would be negative", async () => {
+  const { userId, stockId } = await setupGroupWithStock(2)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/consume`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantityDelta: 10 }),
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_QUANTITY")
+
+  // 失敗時に stock も event も触らないことを確認
+  const [row] = await testDb.select().from(stocks).where(eq(stocks.id, stockId))
+  expect(row?.quantity).toBe(2)
+  const events = await testDb.select().from(stockEvents).where(eq(stockEvents.stockId, stockId))
+  expect(events).toHaveLength(0)
+})
+
+test("POST /v1/stocks/:id/consume by VIEWER returns 403 INSUFFICIENT_ROLE", async () => {
+  const ownerId = await seedUser("Owner")
+  const viewerId = await seedUser("Viewer")
+  const groupId = await seedGroupWithMembership(ownerId, "Home")
+  await seedMembership(viewerId, groupId, "VIEWER")
+  const locationId = await seedLocation(groupId, "Pantry")
+  const itemId = await seedItem(groupId, "Apple")
+  const stockId = await seedStock(groupId, itemId, locationId, 5)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/consume`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": viewerId },
+    body: JSON.stringify({ quantityDelta: 1 }),
+  })
+
+  expect(res.status).toBe(403)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INSUFFICIENT_ROLE")
+})
+
+test("POST /v1/stocks/:id/consume on soft-deleted stock returns 404", async () => {
+  const { userId, stockId } = await setupGroupWithStock(5)
+  await testDb.update(stocks).set({ deletedAt: new Date() }).where(eq(stocks.id, stockId))
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/consume`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantityDelta: 1 }),
+  })
+
+  expect(res.status).toBe(404)
+})
+
+test("POST /v1/stocks/:id/discard records DISCARD event", async () => {
+  const { userId, stockId } = await setupGroupWithStock(8)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/discard`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantityDelta: 2, reason: "expired" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as {
+    stock: { quantity: number }
+    event: { eventType: string; quantityDelta: number }
+  }
+  expect(body.stock.quantity).toBe(6)
+  expect(body.event.eventType).toBe("DISCARD")
+  expect(body.event.quantityDelta).toBe(-2)
+})
+
+test("POST /v1/stocks/:id/move updates locationId + records MOVE event", async () => {
+  const { userId, groupId, locationId, stockId } = await setupGroupWithStock(5)
+  const otherLocationId = await seedLocation(groupId, "Garage")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/move`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ toLocationId: otherLocationId, reason: "rearrange" }),
+  })
+
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as {
+    stock: { locationId: string; quantity: number }
+    event: {
+      eventType: string
+      quantityDelta: number
+      fromLocationId: string | null
+      toLocationId: string | null
+    }
+  }
+  expect(body.stock.locationId).toBe(otherLocationId)
+  expect(body.stock.quantity).toBe(5) // 数量は変わらない
+  expect(body.event.eventType).toBe("MOVE")
+  expect(body.event.quantityDelta).toBe(0)
+  expect(body.event.fromLocationId).toBe(locationId)
+  expect(body.event.toLocationId).toBe(otherLocationId)
+})
+
+test("POST /v1/stocks/:id/move to same location returns 422 MOVE_NOOP", async () => {
+  const { userId, locationId, stockId } = await setupGroupWithStock(5)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/move`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ toLocationId: locationId }),
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("MOVE_NOOP")
+})
+
+test("POST /v1/stocks/:id/move to other group's location returns 422 LOCATION_GROUP_MISMATCH", async () => {
+  const { userId, stockId } = await setupGroupWithStock(5)
+  // 別 group の location を seed
+  const otherOwner = await seedUser("Other")
+  const otherGroupId = await seedGroupWithMembership(otherOwner, "Other")
+  const otherLocationId = await seedLocation(otherGroupId, "Foreign")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}/move`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ toLocationId: otherLocationId }),
+  })
+
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("LOCATION_GROUP_MISMATCH")
+})
+
+test("DELETE /v1/stocks/:id soft-deletes + records final DISCARD event for remaining qty", async () => {
+  const { userId, stockId, groupId } = await setupGroupWithStock(4)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(204)
+
+  const [row] = await testDb.select().from(stocks).where(eq(stocks.id, stockId))
+  expect(row?.deletedAt).not.toBeNull()
+  expect(row?.quantity).toBe(4) // quantity は残す (履歴のため)
+
+  // 残数量分の DISCARD event が記録されている
+  const events = await testDb
+    .select()
+    .from(stockEvents)
+    .where(and(eq(stockEvents.stockId, stockId), eq(stockEvents.eventType, "DISCARD")))
+  expect(events).toHaveLength(1)
+  expect(events[0]?.quantityDelta).toBe(-4)
+  expect(events[0]?.groupId).toBe(groupId)
+  expect(events[0]?.reason).toBe("soft-delete")
+})
+
+test("DELETE /v1/stocks/:id with quantity=0 does not create extra event", async () => {
+  const { userId, stockId } = await setupGroupWithStock(0)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+
+  expect(res.status).toBe(204)
+  const events = await testDb.select().from(stockEvents).where(eq(stockEvents.stockId, stockId))
+  expect(events).toHaveLength(0)
+})
+
+test("After soft-delete, consume on same id returns 404", async () => {
+  const { userId, stockId } = await setupGroupWithStock(5)
+
+  const app = createApp({ db: testDb })
+  const del = await app.request(`/v1/stocks/${stockId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": userId },
+  })
+  expect(del.status).toBe(204)
+
+  const consume = await app.request(`/v1/stocks/${stockId}/consume`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantityDelta: 1 }),
+  })
+  expect(consume.status).toBe(404)
+})

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -213,3 +213,35 @@ export const createStockBodyDtoSchema = z
     note: z.string().nullable(),
   })
   .openapi("CreateStockBody")
+
+export const stockEventDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    stockId: z.string().uuid(),
+    eventType: z.enum(["ADD", "CONSUME", "DISCARD", "MOVE", "EDIT"]),
+    quantityDelta: z.number(),
+    fromLocationId: z.string().uuid().nullable(),
+    toLocationId: z.string().uuid().nullable(),
+    occurredAt: z.string().datetime({ offset: true }),
+    actorUserId: z.string().uuid().nullable(),
+    reason: z.string().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+  })
+  .openapi("StockEvent")
+
+// 数量変動 (consume / discard) の body。quantityDelta は **削減量を正で** 渡す。
+// stock_events には `-quantityDelta` を保存することで集計時の SUM 整合を保つ。
+export const stockQuantityDeltaBodyDtoSchema = z
+  .object({
+    quantityDelta: z.number().positive(),
+    reason: z.string().max(500).nullable().optional(),
+  })
+  .openapi("StockQuantityDeltaBody")
+
+export const stockMoveBodyDtoSchema = z
+  .object({
+    toLocationId: z.string().uuid(),
+    reason: z.string().max(500).nullable().optional(),
+  })
+  .openapi("StockMoveBody")

--- a/apps/core/api/src/routes/stocks.ts
+++ b/apps/core/api/src/routes/stocks.ts
@@ -1,9 +1,23 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { and, eq, isNull } from "drizzle-orm"
-import { memberships, stocks } from "@prep-hamster/db"
+import { locations, memberships, stockEvents, stocks } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
-import { withGroupAccess } from "../middleware/group-access"
-import { createStockBodyDtoSchema, errorResponseSchema, stockDtoSchema } from "./schemas"
+import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
+import {
+  createStockBodyDtoSchema,
+  errorResponseSchema,
+  stockDtoSchema,
+  stockEventDtoSchema,
+  stockMoveBodyDtoSchema,
+  stockQuantityDeltaBodyDtoSchema,
+} from "./schemas"
+
+const IdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "id", in: "path" } }),
+})
 
 const ListQuerySchema = z.object({
   groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
@@ -24,6 +38,22 @@ const toStockDto = (row: typeof stocks.$inferSelect): z.infer<typeof stockDtoSch
   createdAt: row.createdAt.toISOString(),
   updatedAt: row.updatedAt.toISOString(),
   deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const toStockEventDto = (
+  row: typeof stockEvents.$inferSelect,
+): z.infer<typeof stockEventDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  stockId: row.stockId,
+  eventType: row.eventType,
+  quantityDelta: row.quantityDelta,
+  fromLocationId: row.fromLocationId,
+  toLocationId: row.toLocationId,
+  occurredAt: row.occurredAt.toISOString(),
+  actorUserId: row.actorUserId,
+  reason: row.reason,
+  createdAt: row.createdAt.toISOString(),
 })
 
 const listStocksRoute = createRoute({
@@ -97,6 +127,140 @@ const createStockRoute = createRoute({
   },
 })
 
+const consumeStockRoute = createRoute({
+  method: "post",
+  path: "/{id}/consume",
+  tags: ["stocks"],
+  summary: "在庫を消費 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: stockQuantityDeltaBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "消費成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema, event: stockEventDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "数量不正 (delta 負 / 結果が負)",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const discardStockRoute = createRoute({
+  method: "post",
+  path: "/{id}/discard",
+  tags: ["stocks"],
+  summary: "在庫を廃棄 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: stockQuantityDeltaBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "廃棄成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema, event: stockEventDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "数量不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const moveStockRoute = createRoute({
+  method: "post",
+  path: "/{id}/move",
+  tags: ["stocks"],
+  summary: "在庫の保管場所を移動 (EDITOR 以上)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: stockMoveBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "移動成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema, event: stockEventDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "toLocationId が同じ group ではない / 同 location への移動",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const deleteStockRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["stocks"],
+  summary: "在庫を soft delete (EDITOR 以上)",
+  request: { params: IdParamSchema },
+  responses: {
+    204: { description: "削除成功" },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
 export const stocksRouter = new OpenAPIHono<AppEnv>()
   .openapi(listStocksRoute, async (c) => {
     const { groupId } = c.req.valid("query")
@@ -159,4 +323,270 @@ export const stocksRouter = new OpenAPIHono<AppEnv>()
       throw new Error("insert returned no row")
     }
     return c.json({ stock: toStockDto(created) }, 201)
+  })
+  .openapi(consumeStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const newQty = existing.quantity - body.quantityDelta
+    if (newQty < 0) {
+      return c.json(
+        {
+          error: {
+            code: "INSUFFICIENT_QUANTITY",
+            message: `在庫数量 ${existing.quantity} に対して消費量 ${body.quantityDelta} が大きすぎます`,
+          },
+        },
+        422,
+      )
+    }
+
+    // quantity 更新 + stock_events 追加を 1 transaction で原子化。
+    // 失敗時に片方だけ反映されるのを防ぐ。
+    const result = await db.transaction(async (tx) => {
+      const now = new Date()
+      const [updated] = await tx
+        .update(stocks)
+        .set({ quantity: newQty, updatedAt: now })
+        .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+        .returning()
+      if (!updated) {
+        throw new Error("stock update returned no row")
+      }
+      const [event] = await tx
+        .insert(stockEvents)
+        .values({
+          id: crypto.randomUUID(),
+          groupId: existing.groupId,
+          stockId: id,
+          eventType: "CONSUME",
+          // 集計を SUM(quantityDelta) で取れるよう、CONSUME は負値で記録
+          quantityDelta: -body.quantityDelta,
+          fromLocationId: null,
+          toLocationId: null,
+          occurredAt: now,
+          actorUserId: userId,
+          reason: body.reason ?? null,
+        })
+        .returning()
+      if (!event) {
+        throw new Error("stock_event insert returned no row")
+      }
+      return { stock: updated, event }
+    })
+
+    return c.json({ stock: toStockDto(result.stock), event: toStockEventDto(result.event) }, 200)
+  })
+  .openapi(discardStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    const newQty = existing.quantity - body.quantityDelta
+    if (newQty < 0) {
+      return c.json(
+        {
+          error: {
+            code: "INSUFFICIENT_QUANTITY",
+            message: `在庫数量 ${existing.quantity} に対して廃棄量 ${body.quantityDelta} が大きすぎます`,
+          },
+        },
+        422,
+      )
+    }
+
+    const result = await db.transaction(async (tx) => {
+      const now = new Date()
+      const [updated] = await tx
+        .update(stocks)
+        .set({ quantity: newQty, updatedAt: now })
+        .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+        .returning()
+      if (!updated) {
+        throw new Error("stock update returned no row")
+      }
+      const [event] = await tx
+        .insert(stockEvents)
+        .values({
+          id: crypto.randomUUID(),
+          groupId: existing.groupId,
+          stockId: id,
+          eventType: "DISCARD",
+          quantityDelta: -body.quantityDelta,
+          fromLocationId: null,
+          toLocationId: null,
+          occurredAt: now,
+          actorUserId: userId,
+          reason: body.reason ?? null,
+        })
+        .returning()
+      if (!event) {
+        throw new Error("stock_event insert returned no row")
+      }
+      return { stock: updated, event }
+    })
+
+    return c.json({ stock: toStockDto(result.stock), event: toStockEventDto(result.event) }, 200)
+  })
+  .openapi(moveStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    if (body.toLocationId === existing.locationId) {
+      return c.json(
+        {
+          error: {
+            code: "MOVE_NOOP",
+            message: "移動先が現在の locationId と同じです",
+          },
+        },
+        422,
+      )
+    }
+
+    // 移動先 location が同じ group に属することを検証する。
+    // location が deletedAt なら移動先として不正なので除外。
+    const [toLoc] = await db
+      .select({ groupId: locations.groupId })
+      .from(locations)
+      .where(and(eq(locations.id, body.toLocationId), isNull(locations.deletedAt)))
+      .limit(1)
+    if (!toLoc || toLoc.groupId !== existing.groupId) {
+      return c.json(
+        {
+          error: {
+            code: "LOCATION_GROUP_MISMATCH",
+            message: "toLocationId が同じ group の active な location ではありません",
+          },
+        },
+        422,
+      )
+    }
+
+    const result = await db.transaction(async (tx) => {
+      const now = new Date()
+      const [updated] = await tx
+        .update(stocks)
+        .set({ locationId: body.toLocationId, updatedAt: now })
+        .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+        .returning()
+      if (!updated) {
+        throw new Error("stock update returned no row")
+      }
+      const [event] = await tx
+        .insert(stockEvents)
+        .values({
+          id: crypto.randomUUID(),
+          groupId: existing.groupId,
+          stockId: id,
+          eventType: "MOVE",
+          // MOVE は数量変動なし
+          quantityDelta: 0,
+          fromLocationId: existing.locationId,
+          toLocationId: body.toLocationId,
+          occurredAt: now,
+          actorUserId: userId,
+          reason: body.reason ?? null,
+        })
+        .returning()
+      if (!event) {
+        throw new Error("stock_event insert returned no row")
+      }
+      return { stock: updated, event }
+    })
+
+    return c.json({ stock: toStockDto(result.stock), event: toStockEventDto(result.event) }, 200)
+  })
+  .openapi(deleteStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    // soft delete + 残数量を DISCARD として 1 件 stock_event に残すことで、
+    // 過去の集計 (SUM(quantityDelta)) で「いま 0」を再現できる。
+    const now = new Date()
+    await db.transaction(async (tx) => {
+      await tx
+        .update(stocks)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      // 残数量があるなら DISCARD イベントを残す。0 ならイベントは作らない。
+      if (existing.quantity > 0) {
+        await tx.insert(stockEvents).values({
+          id: crypto.randomUUID(),
+          groupId: existing.groupId,
+          stockId: id,
+          eventType: "DISCARD",
+          quantityDelta: -existing.quantity,
+          fromLocationId: null,
+          toLocationId: null,
+          occurredAt: now,
+          actorUserId: userId,
+          reason: "soft-delete",
+        })
+      }
+    })
+
+    return c.body(null, 204)
   })


### PR DESCRIPTION
## 概要 / Why

在庫の数量変動 (消費 / 廃棄) と保管場所移動を API 化し、`stock_events` テーブルに履歴を残すことで UC-11 の分析グラフ基盤を作る。UC-03「在庫を消費 / 廃棄」、UC-04「保管場所を移動」相当。

## 変更内容 / What

### 新エンドポイント
| Path | Body | 役割 |
| --- | --- | --- |
| `POST /v1/stocks/:id/consume` | `{ quantityDelta>0, reason? }` | 数量減 + `CONSUME` event |
| `POST /v1/stocks/:id/discard` | `{ quantityDelta>0, reason? }` | 数量減 + `DISCARD` event |
| `POST /v1/stocks/:id/move` | `{ toLocationId, reason? }` | locationId 変更 + `MOVE` event |
| `DELETE /v1/stocks/:id` | — | soft-delete + 残量 `DISCARD` event |

全 endpoint EDITOR 以上必須。`200` レスポンスは `{ stock, event }`。

### スキーマ
- `stockEventDtoSchema` 新設
- `stockQuantityDeltaBodyDtoSchema` (consume/discard 共通)、`stockMoveBodyDtoSchema`

### 認可
- handler 内 `checkGroupAccess` (path `:id` → `resource.groupId` 経由)
- EDITOR 以上必須

### E2E (`stocks-lifecycle.test.ts` 11 case)
- consume の数量減 + event 記録 / 不足量 → 422 INSUFFICIENT_QUANTITY (stock/event 両方触らない) / VIEWER → 403 / soft-deleted → 404
- discard の DISCARD event 記録
- move の locationId 変更 + from/to 記録 / 同 location → 422 MOVE_NOOP / 別 group → 422 LOCATION_GROUP_MISMATCH
- soft-delete の deletedAt + 残量 DISCARD event / quantity=0 → イベント無し / 削除後 consume → 404

合計 64 E2E pass。

## 設計判断

- **`quantityDelta` の符号**: API では削減量を **正で渡す**。stock_events には `CONSUME` / `DISCARD` を **負値** で記録。これで `SUM(quantityDelta)` がその在庫の現量と整合し集計が単純化
- **consume と discard を別 endpoint に分離**: eventType を body で受けると検証が複雑。UI 操作も別アクション
- **transaction で原子化**: 数量更新と `stock_events` 追加は必ず 1 トランザクション。失敗時に片方だけ反映されるのを防ぐ
- **soft-delete に DISCARD event**: 残数量がある状態で削除されたら、その残量を `DISCARD` event として記録 (`reason: "soft-delete"`)。`quantity=0` の場合はイベントを作らない（無駄なログを残さない）
- **MOVE は数量変動なし**: `quantityDelta=0` で記録、`fromLocationId` / `toLocationId` 両方を必ず埋める

## スコープ外 / Out of scope

- 期限が近い在庫の通知 (UC-05、別 Issue)
- 履歴一覧 endpoint (`GET /v1/stocks/:id/events`、別 Issue にする想定)
- 一括操作 (CLI からの bulk import / export は UC-13 の別 Issue)
- 数量変更時の `StockEvent.actorUserId` 検証ロジック (stub auth のため currentUserId をそのまま記録)

## 検証 / Test plan

- [x] `bun --filter @prep-hamster/api typecheck`
- [x] `bun --filter @prep-hamster/api test:e2e` → 64 pass / 0 fail (うち 11 が #72)
- [x] `bun x oxlint apps/core/api/src apps/core/api/e2e` → 0 errors
- [x] `bun x oxfmt --check apps/core/api/src apps/core/api/e2e` → ok

## 関連 Issue / Links

- Closes #72
- Depends on (merged): #67 / #69 / #70 / #71

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test / E2E / Lint / Format）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 在庫消費機能をAPIに追加し、トランザクション保証付きのイベント記録に対応しました。在庫移動やその他の操作とともに詳細な追跡が可能になります。

* **テスト**
  * 在庫ライフサイクル全体の包括的なテストスイートを追加しました。消費、破棄、移動、削除などの各操作と権限管理をカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->