### PR TITLE
feat(api): /v1/stocks GET-by-id, PATCH, and search filters

### DIFF
--- a/apps/core/api/e2e/seed.ts
+++ b/apps/core/api/e2e/seed.ts
@@ -90,6 +90,7 @@ export async function seedStock(
   itemId: string,
   locationId: string,
   quantity = 1,
+  dates: { useByDate?: string | null; bestBeforeDate?: string | null } = {},
 ): Promise<string> {
   const id = crypto.randomUUID()
   await testDb.insert(stocks).values({
@@ -99,8 +100,8 @@ export async function seedStock(
     locationId,
     quantity,
     unit: "個",
-    useByDate: null,
-    bestBeforeDate: null,
+    useByDate: dates.useByDate ?? null,
+    bestBeforeDate: dates.bestBeforeDate ?? null,
     openedAt: null,
     note: null,
   })

--- a/apps/core/api/e2e/stocks-search.test.ts
+++ b/apps/core/api/e2e/stocks-search.test.ts
@@ -1,0 +1,279 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { createApp } from "../src/app"
+import {
+  seedCategory,
+  seedGroupWithMembership,
+  seedItem,
+  seedLocation,
+  seedStock,
+  seedUser,
+} from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+const isoDate = (offsetDays: number): string => {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + offsetDays)
+  return d.toISOString().slice(0, 10)
+}
+
+test("GET /v1/stocks/:id returns the stock for a member", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  const stockId = await seedStock(groupId, itemId, locationId, 5)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stock: { id: string; quantity: number } }
+  expect(body.stock.id).toBe(stockId)
+  expect(body.stock.quantity).toBe(5)
+})
+
+test("GET /v1/stocks/:id returns 403 for a non-member", async () => {
+  const ownerId = await seedUser("owner")
+  const outsiderId = await seedUser("outsider")
+  const groupId = await seedGroupWithMembership(ownerId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  const stockId = await seedStock(groupId, itemId, locationId, 1)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    headers: { "x-user-id": outsiderId },
+  })
+  expect(res.status).toBe(403)
+})
+
+test("GET /v1/stocks/:id returns 404 for a missing stock", async () => {
+  const userId = await seedUser()
+  await seedGroupWithMembership(userId)
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${crypto.randomUUID()}`, {
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(404)
+})
+
+test("PATCH /v1/stocks/:id rejects quantity in body", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  const stockId = await seedStock(groupId, itemId, locationId, 3)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ quantity: 99, note: "memo" }),
+  })
+  // .strict() で unrecognized_keys を投げ、422 で reject される
+  expect(res.status).toBe(400)
+})
+
+test("PATCH /v1/stocks/:id updates note / unit / dates without changing quantity", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  const stockId = await seedStock(groupId, itemId, locationId, 3)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({
+      note: "updated",
+      unit: "本",
+      useByDate: isoDate(30),
+    }),
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as {
+    stock: { quantity: number; note: string | null; unit: string; useByDate: string | null }
+  }
+  expect(body.stock.quantity).toBe(3)
+  expect(body.stock.note).toBe("updated")
+  expect(body.stock.unit).toBe("本")
+  expect(body.stock.useByDate).toBe(isoDate(30))
+})
+
+test("PATCH /v1/stocks/:id with locationId in another group returns 422", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId, "Group A")
+  const otherGroupId = await seedGroupWithMembership(userId, "Group B")
+  const locationId = await seedLocation(groupId)
+  const otherLocationId = await seedLocation(otherGroupId, "Other Pantry")
+  const itemId = await seedItem(groupId)
+  const stockId = await seedStock(groupId, itemId, locationId, 1)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks/${stockId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": userId },
+    body: JSON.stringify({ locationId: otherLocationId }),
+  })
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("LOCATION_GROUP_MISMATCH")
+})
+
+test("GET /v1/stocks?categoryId filters by item.categoryId", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const foodCategoryId = await seedCategory(groupId, "Food")
+  const drinkCategoryId = await seedCategory(groupId, "Drink")
+  const foodItemId = await seedItem(groupId, "Tomato", foodCategoryId)
+  const drinkItemId = await seedItem(groupId, "Tea", drinkCategoryId)
+  const noCatItemId = await seedItem(groupId, "Misc")
+  await seedStock(groupId, foodItemId, locationId, 1)
+  await seedStock(groupId, drinkItemId, locationId, 1)
+  await seedStock(groupId, noCatItemId, locationId, 1)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(
+    `/v1/stocks?groupId=${groupId}&categoryId=${foodCategoryId}&includeExpired=true`,
+    { headers: { "x-user-id": userId } },
+  )
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { itemId: string }[] }
+  expect(body.stocks).toHaveLength(1)
+  expect(body.stocks[0]?.itemId).toBe(foodItemId)
+})
+
+test("GET /v1/stocks?locationId filters by stock.locationId", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const pantryId = await seedLocation(groupId, "Pantry")
+  const fridgeId = await seedLocation(groupId, "Fridge")
+  const itemId = await seedItem(groupId)
+  await seedStock(groupId, itemId, pantryId, 1)
+  await seedStock(groupId, itemId, fridgeId, 1)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(
+    `/v1/stocks?groupId=${groupId}&locationId=${fridgeId}&includeExpired=true`,
+    { headers: { "x-user-id": userId } },
+  )
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { locationId: string }[] }
+  expect(body.stocks).toHaveLength(1)
+  expect(body.stocks[0]?.locationId).toBe(fridgeId)
+})
+
+test("GET /v1/stocks excludes expired stocks by default", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  // 期限切れ (use-by 過去)
+  const expiredId = await seedStock(groupId, itemId, locationId, 1, {
+    useByDate: isoDate(-5),
+  })
+  // 期限内
+  const freshId = await seedStock(groupId, itemId, locationId, 1, {
+    useByDate: isoDate(10),
+  })
+  // 期限なし (null)
+  const noExpiryId = await seedStock(groupId, itemId, locationId, 1)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${groupId}`, {
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { id: string }[] }
+  const ids = body.stocks.map((s) => s.id)
+  expect(ids).toContain(freshId)
+  expect(ids).toContain(noExpiryId)
+  expect(ids).not.toContain(expiredId)
+})
+
+test("GET /v1/stocks?includeExpired=true includes expired", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  const expiredId = await seedStock(groupId, itemId, locationId, 1, {
+    useByDate: isoDate(-3),
+  })
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${groupId}&includeExpired=true`, {
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { id: string }[] }
+  expect(body.stocks.map((s) => s.id)).toContain(expiredId)
+})
+
+test("GET /v1/stocks?expiringBefore filters by useByDate or bestBeforeDate", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  // useByDate が境界以内
+  const useByMatch = await seedStock(groupId, itemId, locationId, 1, {
+    useByDate: isoDate(5),
+  })
+  // bestBeforeDate が境界以内
+  const bestMatch = await seedStock(groupId, itemId, locationId, 1, {
+    bestBeforeDate: isoDate(3),
+  })
+  // どちらも境界より先
+  await seedStock(groupId, itemId, locationId, 1, {
+    useByDate: isoDate(60),
+  })
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(
+    `/v1/stocks?groupId=${groupId}&expiringBefore=${isoDate(7)}&includeExpired=true`,
+    { headers: { "x-user-id": userId } },
+  )
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { id: string }[] }
+  const ids = body.stocks.map((s) => s.id)
+  expect(ids).toContain(useByMatch)
+  expect(ids).toContain(bestMatch)
+  expect(ids).toHaveLength(2)
+})
+
+test("GET /v1/stocks orders by useByDate ASC NULLS LAST then bestBeforeDate ASC NULLS LAST", async () => {
+  const userId = await seedUser()
+  const groupId = await seedGroupWithMembership(userId)
+  const locationId = await seedLocation(groupId)
+  const itemId = await seedItem(groupId)
+  // 期限なし
+  const noExpiry = await seedStock(groupId, itemId, locationId, 1)
+  // useByDate あり、近い
+  const soon = await seedStock(groupId, itemId, locationId, 1, { useByDate: isoDate(3) })
+  // useByDate あり、遠い
+  const later = await seedStock(groupId, itemId, locationId, 1, { useByDate: isoDate(20) })
+  // useByDate null, bestBeforeDate あり
+  const bestOnly = await seedStock(groupId, itemId, locationId, 1, {
+    bestBeforeDate: isoDate(10),
+  })
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/stocks?groupId=${groupId}&includeExpired=true`, {
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { stocks: { id: string }[] }
+  const order = body.stocks.map((s) => s.id)
+  // useByDate 近い → 遠い、その後 useByDate=null 群 (bestBeforeDate 近い → null)
+  expect(order).toEqual([soon, later, bestOnly, noExpiry])
+})

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -214,6 +214,20 @@ export const createStockBodyDtoSchema = z
   })
   .openapi("CreateStockBody")
 
+// quantity は consume / move / discard / soft-delete 経由で履歴を残しつつ更新する方針のため、
+// PATCH では受け付けない。.strict() で未知キー (quantity を含む) を 422 で reject する。
+export const updateStockBodyDtoSchema = z
+  .object({
+    locationId: z.string().uuid().optional(),
+    unit: z.string().min(1).optional(),
+    useByDate: z.string().date().nullable().optional(),
+    bestBeforeDate: z.string().date().nullable().optional(),
+    openedAt: z.string().date().nullable().optional(),
+    note: z.string().nullable().optional(),
+  })
+  .strict()
+  .openapi("UpdateStockBody")
+
 export const stockEventDtoSchema = z
   .object({
     id: z.string().uuid(),

--- a/apps/core/api/src/routes/stocks.ts
+++ b/apps/core/api/src/routes/stocks.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
-import { and, eq, isNull } from "drizzle-orm"
-import { locations, memberships, stockEvents, stocks } from "@prep-hamster/db"
+import { and, asc, eq, isNull, lte, or, sql } from "drizzle-orm"
+import { items, locations, memberships, stockEvents, stocks } from "@prep-hamster/db"
 import type { AppEnv } from "../app"
 import { checkGroupAccess, withGroupAccess } from "../middleware/group-access"
 import {
@@ -10,6 +10,7 @@ import {
   stockEventDtoSchema,
   stockMoveBodyDtoSchema,
   stockQuantityDeltaBodyDtoSchema,
+  updateStockBodyDtoSchema,
 } from "./schemas"
 
 const IdParamSchema = z.object({
@@ -19,8 +20,18 @@ const IdParamSchema = z.object({
     .openapi({ param: { name: "id", in: "path" } }),
 })
 
+// `?includeExpired=true` のように文字列で来るため、boolean は文字列パース後に変換する。
+const booleanQuery = z
+  .enum(["true", "false"])
+  .transform((v) => v === "true")
+  .openapi({ type: "boolean" })
+
 const ListQuerySchema = z.object({
   groupId: z.string().uuid().openapi({ example: "00000000-0000-0000-0000-000000000000" }),
+  categoryId: z.string().uuid().optional(),
+  locationId: z.string().uuid().optional(),
+  expiringBefore: z.string().date().optional(),
+  includeExpired: booleanQuery.optional(),
 })
 
 // drizzle 行を API DTO 形式 (timestamp は ISO string、id は plain UUID) に変換
@@ -60,14 +71,14 @@ const listStocksRoute = createRoute({
   method: "get",
   path: "/",
   tags: ["stocks"],
-  summary: "在庫一覧を取得",
+  summary: "在庫一覧を取得 (categoryId / locationId / 期限で絞り込み可)",
   middleware: [withGroupAccess((c) => c.req.query("groupId"))] as const,
   request: {
     query: ListQuerySchema,
   },
   responses: {
     200: {
-      description: "在庫一覧",
+      description: "在庫一覧 (useByDate ASC NULLS LAST, bestBeforeDate ASC NULLS LAST)",
       content: {
         "application/json": {
           schema: z.object({ stocks: z.array(stockDtoSchema) }),
@@ -84,6 +95,73 @@ const listStocksRoute = createRoute({
     },
     422: {
       description: "クエリ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const getStockRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["stocks"],
+  summary: "在庫を 1 件取得",
+  request: { params: IdParamSchema },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchStockRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["stocks"],
+  summary: "在庫の属性を部分更新 (EDITOR 以上、quantity は対象外)",
+  request: {
+    params: IdParamSchema,
+    body: { content: { "application/json": { schema: updateStockBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": {
+          schema: z.object({ stock: stockDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加 / role 不足",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正 (quantity を含む / 移動先 location が group 外)",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -263,15 +341,137 @@ const deleteStockRoute = createRoute({
 
 export const stocksRouter = new OpenAPIHono<AppEnv>()
   .openapi(listStocksRoute, async (c) => {
-    const { groupId } = c.req.valid("query")
+    const { groupId, categoryId, locationId, expiringBefore, includeExpired } = c.req.valid("query")
     const db = c.get("db")
 
-    const rows = await db
+    // YYYY-MM-DD 文字列で比較するため、PG 上の DATE 列に対しても辞書順 = 日付順で正しく動く。
+    const today = new Date().toISOString().slice(0, 10)
+
+    const conditions = [eq(stocks.groupId, groupId), isNull(stocks.deletedAt)]
+    if (locationId) {
+      conditions.push(eq(stocks.locationId, locationId))
+    }
+    if (expiringBefore) {
+      // 「いずれかの期限日が指定日以前」= useByDate <= X OR bestBeforeDate <= X
+      const expiringCond = or(
+        lte(stocks.useByDate, expiringBefore),
+        lte(stocks.bestBeforeDate, expiringBefore),
+      )
+      if (expiringCond) conditions.push(expiringCond)
+    }
+    if (!includeExpired) {
+      // 既に期限切れ (useByDate or bestBeforeDate <= today) のものを除外。
+      // null は期限が無いので残す。
+      const notExpired = and(
+        or(isNull(stocks.useByDate), sql`${stocks.useByDate} > ${today}`),
+        or(isNull(stocks.bestBeforeDate), sql`${stocks.bestBeforeDate} > ${today}`),
+      )
+      if (notExpired) conditions.push(notExpired)
+    }
+
+    const baseQuery = db
+      .select({ stock: stocks })
+      .from(stocks)
+      // categoryId は items 経由で絞る。filter 無しでも JOIN すると stocks 列に影響するため、
+      // categoryId 指定時のみ JOIN を追加する。
+      .$dynamic()
+
+    const query = categoryId
+      ? baseQuery
+          .innerJoin(items, eq(stocks.itemId, items.id))
+          .where(and(...conditions, eq(items.categoryId, categoryId)))
+      : baseQuery.where(and(...conditions))
+
+    const rows = await query.orderBy(
+      sql`${stocks.useByDate} ASC NULLS LAST`,
+      sql`${stocks.bestBeforeDate} ASC NULLS LAST`,
+      asc(stocks.createdAt),
+    )
+
+    return c.json({ stocks: rows.map((r) => toStockDto(r.stock)) }, 200)
+  })
+  .openapi(getStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
       .select()
       .from(stocks)
-      .where(and(eq(stocks.groupId, groupId), isNull(stocks.deletedAt)))
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
 
-    return c.json({ stocks: rows.map(toStockDto) }, 200)
+    const access = await checkGroupAccess(db, userId, existing.groupId)
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    return c.json({ stock: toStockDto(existing) }, 200)
+  })
+  .openapi(patchStockRoute, async (c) => {
+    const { id } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [existing] = await db
+      .select()
+      .from(stocks)
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .limit(1)
+    if (!existing) {
+      return c.json({ error: { code: "NOT_FOUND", message: "stock が見つかりません" } }, 404)
+    }
+
+    const access = await checkGroupAccess(db, userId, existing.groupId, "EDITOR")
+    if (!access.ok) {
+      return c.json(access.body, access.status)
+    }
+
+    // locationId 変更を PATCH で許容するが、move エンドポイントとは違い stock_events への
+    // MOVE 記録は行わない (PATCH は属性訂正系。物理移動は /move を使うこと)。
+    // ただし group をまたいだ location は弾く。
+    if (body.locationId && body.locationId !== existing.locationId) {
+      const [toLoc] = await db
+        .select({ groupId: locations.groupId })
+        .from(locations)
+        .where(and(eq(locations.id, body.locationId), isNull(locations.deletedAt)))
+        .limit(1)
+      if (!toLoc || toLoc.groupId !== existing.groupId) {
+        return c.json(
+          {
+            error: {
+              code: "LOCATION_GROUP_MISMATCH",
+              message: "locationId が同じ group の active な location ではありません",
+            },
+          },
+          422,
+        )
+      }
+    }
+
+    const now = new Date()
+    const [updated] = await db
+      .update(stocks)
+      .set({
+        ...(body.locationId !== undefined && { locationId: body.locationId }),
+        ...(body.unit !== undefined && { unit: body.unit }),
+        ...(body.useByDate !== undefined && { useByDate: body.useByDate }),
+        ...(body.bestBeforeDate !== undefined && { bestBeforeDate: body.bestBeforeDate }),
+        ...(body.openedAt !== undefined && { openedAt: body.openedAt }),
+        ...(body.note !== undefined && { note: body.note }),
+        updatedAt: now,
+      })
+      .where(and(eq(stocks.id, id), isNull(stocks.deletedAt)))
+      .returning()
+    if (!updated) {
+      throw new Error("stock update returned no row")
+    }
+
+    return c.json({ stock: toStockDto(updated) }, 200)
   })
   .openapi(createStockRoute, async (c) => {
     const body = c.req.valid("json")


### PR DESCRIPTION
## 概要 / Why

`/v1/stocks` の単件取得・部分更新・絞り込みを追加して stocks の CRUD を完成させる。UC-06「カテゴリ・保管場所で絞り込み」に対応する。

## 変更内容 / What

### エンドポイント
- `GET /v1/stocks/:id` — group access チェックの上で 1 件取得
- `PATCH /v1/stocks/:id` — `note / unit / dates / locationId` の部分更新
  - **`quantity` は受け付けない**: 履歴 (StockEvent) を維持するため、数量変更は `consume / move / discard` 経由
  - `updateStockBodyDtoSchema` に `.strict()` を付与し、`quantity` を含む未知キーは validation error で reject (現状の error handler は 400)
  - `locationId` 変更時は同 group の active な location かを検証 (group をまたぐ変更は 422)
- `GET /v1/stocks?groupId=&categoryId=&locationId=&expiringBefore=&includeExpired=`
  - `categoryId` は items を JOIN して `items.categoryId` で絞る
  - `locationId` は `stocks.locationId` で絞る
  - `expiringBefore=YYYY-MM-DD`: `useByDate <= X OR bestBeforeDate <= X`
  - `includeExpired=false` (default): `useByDate / bestBeforeDate` が今日以前の stock を除外。null は期限なしとして残す
  - 並び順: `useByDate ASC NULLS LAST, bestBeforeDate ASC NULLS LAST, createdAt ASC`

### スキーマ
- `updateStockBodyDtoSchema`: `quantity` を含めず `.strict()`
- `ListQuerySchema`: `categoryId / locationId / expiringBefore / includeExpired` を optional で追加

## スコープ外 / Out of scope

- 全文検索 (item name LIKE) — 必要時に別 Issue
- ページネーション (cursor / limit) — 数百件規模では当面不要
- export endpoint (CLI bulk export は UC-13 別 Issue)

## 検証 / Test plan

- [x] `bun run --filter @prep-hamster/api typecheck`
- [x] `bun run --filter @prep-hamster/api test:e2e` (76 tests pass; +12 ケース追加)
- [x] `bun x oxfmt --check` / `bun x oxlint`

### 追加 E2E (12 ケース)
- GET/:id member 200 / non-member 403 / not-found 404
- PATCH `quantity` 含み reject (`.strict()` で validation error)
- PATCH note/unit/dates 反映、quantity 不変
- PATCH locationId 異 group 422
- categoryId / locationId / expiringBefore 各フィルタ
- includeExpired default 除外 / true 含有
- sort: useByDate ASC, NULLS LAST → bestBeforeDate fallback

## 関連 Issue / Links

- Closes #73
- 依存: #67 (groups), #69 (group access), #70 (locations/categories), #71 (items), #72 (stocks lifecycle)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [ ] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 在庫の個別取得エンドポイント（GET）を追加
  * 在庫情報の部分更新エンドポイント（PATCH）を追加
  * 有効期限日およびカテゴリによる詳細フィルタリング機能を実装
  * 有効期限日でのソート機能を強化

* **テスト**
  * 在庫APIの包括的なE2Eテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->