### PR TITLE
feat(api): add /v1/memberships and /v1/invitations endpoints

### DIFF
--- a/apps/core/api/e2e/invitations.test.ts
+++ b/apps/core/api/e2e/invitations.test.ts
@@ -1,0 +1,168 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { eq } from "drizzle-orm"
+import { invitations } from "@prep-hamster/db"
+import { createApp } from "../src/app"
+import { seedGroupWithMembership, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+async function createInvitation(
+  ownerId: string,
+  groupId: string,
+  role: "EDITOR" | "VIEWER" = "EDITOR",
+) {
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/invitations`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": ownerId },
+    body: JSON.stringify({ role }),
+  })
+  if (res.status !== 201) {
+    throw new Error(`createInvitation failed: ${res.status} ${await res.text()}`)
+  }
+  return (await res.json()) as { invitation: { token: string; role: string; groupId: string } }
+}
+
+test("POST /v1/groups/:groupId/invitations issues a token (OWNER only)", async () => {
+  const ownerId = await seedUser("owner")
+  const groupId = await seedGroupWithMembership(ownerId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/invitations`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": ownerId },
+    body: JSON.stringify({ role: "EDITOR" }),
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as {
+    invitation: { token: string; role: string; expiresAt: string; groupId: string }
+  }
+  expect(body.invitation.role).toBe("EDITOR")
+  expect(body.invitation.token).toMatch(/^[0-9a-f-]{36}$/)
+  expect(body.invitation.groupId).toBe(groupId)
+  // 期限は default 7 日後 (前後 1 分の許容)
+  const diff = new Date(body.invitation.expiresAt).getTime() - Date.now()
+  expect(diff).toBeGreaterThan(6 * 24 * 60 * 60 * 1000)
+  expect(diff).toBeLessThan(8 * 24 * 60 * 60 * 1000)
+})
+
+test("POST /v1/groups/:groupId/invitations by EDITOR returns 403", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/invitations`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-user-id": editorId },
+    body: JSON.stringify({ role: "EDITOR" }),
+  })
+  expect(res.status).toBe(403)
+})
+
+test("POST /v1/invitations/:token/accept creates membership and marks token used", async () => {
+  const ownerId = await seedUser("owner")
+  const newcomerId = await seedUser("newcomer")
+  const groupId = await seedGroupWithMembership(ownerId)
+  const created = await createInvitation(ownerId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/invitations/${created.invitation.token}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": newcomerId },
+  })
+  expect(res.status).toBe(201)
+  const body = (await res.json()) as { membership: { userId: string; role: string } }
+  expect(body.membership.userId).toBe(newcomerId)
+  expect(body.membership.role).toBe("EDITOR")
+
+  // token は used 状態に更新される
+  const [row] = await testDb
+    .select()
+    .from(invitations)
+    .where(eq(invitations.token, created.invitation.token))
+    .limit(1)
+  expect(row?.usedAt).not.toBeNull()
+  expect(row?.usedBy).toBe(newcomerId)
+})
+
+test("accept on used token returns 409 INVITATION_USED", async () => {
+  const ownerId = await seedUser("owner")
+  const a = await seedUser("a")
+  const b = await seedUser("b")
+  const groupId = await seedGroupWithMembership(ownerId)
+  const created = await createInvitation(ownerId, groupId)
+
+  const app = createApp({ db: testDb })
+  const first = await app.request(`/v1/invitations/${created.invitation.token}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": a },
+  })
+  expect(first.status).toBe(201)
+
+  const second = await app.request(`/v1/invitations/${created.invitation.token}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": b },
+  })
+  expect(second.status).toBe(409)
+  const body = (await second.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INVITATION_USED")
+})
+
+test("accept on expired token returns 422 INVITATION_EXPIRED", async () => {
+  const ownerId = await seedUser("owner")
+  const newcomerId = await seedUser("newcomer")
+  const groupId = await seedGroupWithMembership(ownerId)
+  const created = await createInvitation(ownerId, groupId)
+
+  // expiresAt を過去に手動で書き戻す
+  await testDb
+    .update(invitations)
+    .set({ expiresAt: new Date(Date.now() - 1000) })
+    .where(eq(invitations.token, created.invitation.token))
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/invitations/${created.invitation.token}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": newcomerId },
+  })
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("INVITATION_EXPIRED")
+})
+
+test("accept by existing member returns 409 ALREADY_MEMBER", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+  const created = await createInvitation(ownerId, groupId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/invitations/${created.invitation.token}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": editorId },
+  })
+  expect(res.status).toBe(409)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("ALREADY_MEMBER")
+})
+
+test("accept on non-existent token returns 404", async () => {
+  const userId = await seedUser()
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/invitations/${crypto.randomUUID()}/accept`, {
+    method: "POST",
+    headers: { "x-user-id": userId },
+  })
+  expect(res.status).toBe(404)
+})

--- a/apps/core/api/e2e/memberships.test.ts
+++ b/apps/core/api/e2e/memberships.test.ts
@@ -1,0 +1,140 @@
+import { beforeAll, beforeEach, expect, test } from "bun:test"
+import { createApp } from "../src/app"
+import { seedGroupWithMembership, seedMembership, seedUser } from "./seed"
+import { ensureMigrated, testDb, truncateAll } from "./setup"
+
+beforeAll(async () => {
+  await ensureMigrated()
+})
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+test("GET /v1/groups/:groupId/memberships returns members for any member", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships`, {
+    headers: { "x-user-id": editorId },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { memberships: { userId: string; role: string }[] }
+  expect(body.memberships).toHaveLength(2)
+  const roles = new Map(body.memberships.map((m) => [m.userId, m.role]))
+  expect(roles.get(ownerId)).toBe("OWNER")
+  expect(roles.get(editorId)).toBe("EDITOR")
+})
+
+test("GET /v1/groups/:groupId/memberships returns 403 for non-member", async () => {
+  const ownerId = await seedUser("owner")
+  const outsiderId = await seedUser("outsider")
+  const groupId = await seedGroupWithMembership(ownerId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships`, {
+    headers: { "x-user-id": outsiderId },
+  })
+  expect(res.status).toBe(403)
+})
+
+test("PATCH /v1/groups/:groupId/memberships/:userId promotes EDITOR to OWNER (OWNER only)", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${editorId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": ownerId },
+    body: JSON.stringify({ role: "OWNER" }),
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { membership: { role: string } }
+  expect(body.membership.role).toBe("OWNER")
+})
+
+test("PATCH membership by EDITOR returns 403", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const viewerId = await seedUser("viewer")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+  await seedMembership(viewerId, groupId, "VIEWER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${viewerId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": editorId },
+    body: JSON.stringify({ role: "EDITOR" }),
+  })
+  expect(res.status).toBe(403)
+})
+
+test("PATCH self OWNER → EDITOR returns 422 SELF_OWNER_DEMOTE", async () => {
+  const ownerId = await seedUser("owner")
+  const groupId = await seedGroupWithMembership(ownerId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${ownerId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-user-id": ownerId },
+    body: JSON.stringify({ role: "EDITOR" }),
+  })
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("SELF_OWNER_DEMOTE")
+})
+
+test("DELETE last OWNER returns 422 LAST_OWNER", async () => {
+  const ownerId = await seedUser("owner")
+  const groupId = await seedGroupWithMembership(ownerId)
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${ownerId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": ownerId },
+  })
+  expect(res.status).toBe(422)
+  const body = (await res.json()) as { error: { code: string } }
+  expect(body.error.code).toBe("LAST_OWNER")
+})
+
+test("DELETE OWNER when another OWNER exists returns 204", async () => {
+  const owner1 = await seedUser("owner1")
+  const owner2 = await seedUser("owner2")
+  const groupId = await seedGroupWithMembership(owner1)
+  await seedMembership(owner2, groupId, "OWNER")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${owner2}`, {
+    method: "DELETE",
+    headers: { "x-user-id": owner1 },
+  })
+  expect(res.status).toBe(204)
+
+  // 二度目はもう deletedAt が立っているので 404
+  const res2 = await app.request(`/v1/groups/${groupId}/memberships/${owner2}`, {
+    method: "DELETE",
+    headers: { "x-user-id": owner1 },
+  })
+  expect(res2.status).toBe(404)
+})
+
+test("DELETE EDITOR by OWNER returns 204", async () => {
+  const ownerId = await seedUser("owner")
+  const editorId = await seedUser("editor")
+  const groupId = await seedGroupWithMembership(ownerId)
+  await seedMembership(editorId, groupId, "EDITOR")
+
+  const app = createApp({ db: testDb })
+  const res = await app.request(`/v1/groups/${groupId}/memberships/${editorId}`, {
+    method: "DELETE",
+    headers: { "x-user-id": ownerId },
+  })
+  expect(res.status).toBe(204)
+})

--- a/apps/core/api/src/app.ts
+++ b/apps/core/api/src/app.ts
@@ -7,8 +7,10 @@ import { withDb } from "./middleware/db"
 import { onError } from "./middleware/error"
 import { categoriesRouter } from "./routes/categories"
 import { groupsRouter } from "./routes/groups"
+import { invitationsRouter } from "./routes/invitations"
 import { itemsRouter } from "./routes/items"
 import { locationsRouter } from "./routes/locations"
+import { membershipsRouter } from "./routes/memberships"
 import { stocksRouter } from "./routes/stocks"
 
 export type AppEnv = {
@@ -52,13 +54,19 @@ export function createApp(opts: CreateAppOptions) {
 
   // route 定義をチェイン化することで `hc<typeof app>` が
   // 全 endpoint を型として認識できるようにする。
-  return app
-    .get("/health", (c) => c.json({ ok: true as const }))
-    .route("/v1/groups", groupsRouter)
-    .route("/v1/locations", locationsRouter)
-    .route("/v1/categories", categoriesRouter)
-    .route("/v1/items", itemsRouter)
-    .route("/v1/stocks", stocksRouter)
+  return (
+    app
+      .get("/health", (c) => c.json({ ok: true as const }))
+      .route("/v1/groups", groupsRouter)
+      .route("/v1/locations", locationsRouter)
+      .route("/v1/categories", categoriesRouter)
+      .route("/v1/items", itemsRouter)
+      .route("/v1/stocks", stocksRouter)
+      // memberships / invitations は full-path (`/v1/groups/{groupId}/...` and
+      // `/v1/invitations/{token}/accept`) で書いているため `/v1` 直下にまとめてマウント。
+      .route("/v1", membershipsRouter)
+      .route("/v1", invitationsRouter)
+  )
 }
 
 export type AppType = ReturnType<typeof createApp>

--- a/apps/core/api/src/routes/invitations.ts
+++ b/apps/core/api/src/routes/invitations.ts
@@ -1,0 +1,236 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, eq, isNull } from "drizzle-orm"
+import { invitations, memberships } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import { withGroupAccess } from "../middleware/group-access"
+import {
+  createInvitationBodyDtoSchema,
+  errorResponseSchema,
+  invitationDtoSchema,
+  membershipDtoSchema,
+} from "./schemas"
+
+const GroupParamSchema = z.object({
+  groupId: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "groupId", in: "path" } }),
+})
+
+const TokenParamSchema = z.object({
+  token: z
+    .string()
+    .min(1)
+    .openapi({ param: { name: "token", in: "path" } }),
+})
+
+const DEFAULT_EXPIRES_IN_DAYS = 7
+
+const toInvitationDto = (
+  row: typeof invitations.$inferSelect,
+): z.infer<typeof invitationDtoSchema> => ({
+  id: row.id,
+  groupId: row.groupId,
+  inviterId: row.inviterId,
+  role: row.role,
+  token: row.token,
+  expiresAt: row.expiresAt.toISOString(),
+  usedAt: row.usedAt ? row.usedAt.toISOString() : null,
+  usedBy: row.usedBy,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const createInvitationRoute = createRoute({
+  method: "post",
+  path: "/groups/{groupId}/invitations",
+  tags: ["invitations"],
+  summary: "招待トークンを発行 (OWNER のみ)",
+  middleware: [withGroupAccess((c) => c.req.param("groupId"), "OWNER")] as const,
+  request: {
+    params: GroupParamSchema,
+    body: { content: { "application/json": { schema: createInvitationBodyDtoSchema } } },
+  },
+  responses: {
+    201: {
+      description: "発行成功",
+      content: {
+        "application/json": {
+          schema: z.object({ invitation: invitationDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "OWNER でない / 未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const acceptInvitationRoute = createRoute({
+  method: "post",
+  path: "/invitations/{token}/accept",
+  tags: ["invitations"],
+  summary: "招待トークンで group に参加",
+  request: { params: TokenParamSchema },
+  responses: {
+    201: {
+      description: "参加成功 (新規 membership)",
+      content: {
+        "application/json": {
+          schema: z.object({ membership: membershipDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "token が存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "token 使用済み / 既に当該 group の member",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "token 期限切れ",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const invitationsRouter = new OpenAPIHono<AppEnv>()
+  .openapi(createInvitationRoute, async (c) => {
+    const { groupId } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const inviterId = c.get("userId")
+
+    const expiresInDays = body.expiresInDays ?? DEFAULT_EXPIRES_IN_DAYS
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+
+    const [created] = await db
+      .insert(invitations)
+      .values({
+        id: crypto.randomUUID(),
+        groupId,
+        inviterId,
+        role: body.role,
+        // v1.0.0 では UUID をそのまま token に使う。URL safe で衝突確率も無視できる。
+        // 推測されにくくしたいなら別 Issue で `randomBytes(32).toString("base64url")` 等に置換可能。
+        token: crypto.randomUUID(),
+        expiresAt,
+      })
+      .returning()
+    if (!created) {
+      throw new Error("invitation insert returned no row")
+    }
+
+    return c.json({ invitation: toInvitationDto(created) }, 201)
+  })
+  .openapi(acceptInvitationRoute, async (c) => {
+    const { token } = c.req.valid("param")
+    const db = c.get("db")
+    const userId = c.get("userId")
+
+    const [invitation] = await db
+      .select()
+      .from(invitations)
+      .where(and(eq(invitations.token, token), isNull(invitations.deletedAt)))
+      .limit(1)
+    if (!invitation) {
+      return c.json({ error: { code: "NOT_FOUND", message: "招待トークンが見つかりません" } }, 404)
+    }
+    if (invitation.usedAt) {
+      return c.json(
+        {
+          error: { code: "INVITATION_USED", message: "招待トークンは使用済みです" },
+        },
+        409,
+      )
+    }
+    if (invitation.expiresAt.getTime() <= Date.now()) {
+      return c.json(
+        {
+          error: { code: "INVITATION_EXPIRED", message: "招待トークンの有効期限が切れています" },
+        },
+        422,
+      )
+    }
+
+    // 既に member の場合は冪等性を取らず 409 を返す。再 invite ではなく前回の token を使い直す
+    // のが想定運用なため、エラーで知らせた方が分かりやすい。
+    const [existing] = await db
+      .select({ id: memberships.id })
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.groupId, invitation.groupId),
+          eq(memberships.userId, userId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+    if (existing) {
+      return c.json(
+        {
+          error: {
+            code: "ALREADY_MEMBER",
+            message: "既に当該 group の member です",
+          },
+        },
+        409,
+      )
+    }
+
+    const now = new Date()
+    const created = await db.transaction(async (tx) => {
+      // membership 作成と invitation 消化を 1 tx に閉じる。
+      // 失敗時に「token は消えたが membership は無い」状態を防ぐ。
+      const [m] = await tx
+        .insert(memberships)
+        .values({
+          id: crypto.randomUUID(),
+          userId,
+          groupId: invitation.groupId,
+          role: invitation.role,
+          joinedAt: now,
+        })
+        .returning()
+      if (!m) {
+        throw new Error("membership insert returned no row")
+      }
+      await tx
+        .update(invitations)
+        .set({ usedAt: now, usedBy: userId, updatedAt: now })
+        .where(eq(invitations.id, invitation.id))
+      return m
+    })
+
+    return c.json(
+      {
+        membership: {
+          id: created.id,
+          userId: created.userId,
+          groupId: created.groupId,
+          role: created.role,
+          joinedAt: created.joinedAt.toISOString(),
+          createdAt: created.createdAt.toISOString(),
+          updatedAt: created.updatedAt.toISOString(),
+          deletedAt: created.deletedAt ? created.deletedAt.toISOString() : null,
+        },
+      },
+      201,
+    )
+  })

--- a/apps/core/api/src/routes/memberships.ts
+++ b/apps/core/api/src/routes/memberships.ts
@@ -1,0 +1,262 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
+import { and, count, eq, isNull, ne } from "drizzle-orm"
+import { memberships } from "@prep-hamster/db"
+import type { AppEnv } from "../app"
+import { withGroupAccess } from "../middleware/group-access"
+import {
+  errorResponseSchema,
+  membershipDtoSchema,
+  updateMembershipRoleBodyDtoSchema,
+} from "./schemas"
+
+const GroupAndUserParamSchema = z.object({
+  groupId: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "groupId", in: "path" } }),
+  userId: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "userId", in: "path" } }),
+})
+
+const GroupParamSchema = z.object({
+  groupId: z
+    .string()
+    .uuid()
+    .openapi({ param: { name: "groupId", in: "path" } }),
+})
+
+const toMembershipDto = (
+  row: typeof memberships.$inferSelect,
+): z.infer<typeof membershipDtoSchema> => ({
+  id: row.id,
+  userId: row.userId,
+  groupId: row.groupId,
+  role: row.role,
+  joinedAt: row.joinedAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+})
+
+const listMembershipsRoute = createRoute({
+  method: "get",
+  path: "/groups/{groupId}/memberships",
+  tags: ["memberships"],
+  summary: "group の member 一覧 (member 全員に open)",
+  middleware: [withGroupAccess((c) => c.req.param("groupId"))] as const,
+  request: { params: GroupParamSchema },
+  responses: {
+    200: {
+      description: "member 一覧",
+      content: {
+        "application/json": {
+          schema: z.object({ memberships: z.array(membershipDtoSchema) }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const patchMembershipRoute = createRoute({
+  method: "patch",
+  path: "/groups/{groupId}/memberships/{userId}",
+  tags: ["memberships"],
+  summary: "メンバーの role を変更 (OWNER のみ、自分の OWNER 剥奪不可)",
+  middleware: [withGroupAccess((c) => c.req.param("groupId"), "OWNER")] as const,
+  request: {
+    params: GroupAndUserParamSchema,
+    body: { content: { "application/json": { schema: updateMembershipRoleBodyDtoSchema } } },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": {
+          schema: z.object({ membership: membershipDtoSchema }),
+        },
+      },
+    },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "OWNER でない / 未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "対象メンバーが存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "ボディ不正 / 自分の OWNER 剥奪を試行",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const deleteMembershipRoute = createRoute({
+  method: "delete",
+  path: "/groups/{groupId}/memberships/{userId}",
+  tags: ["memberships"],
+  summary: "メンバーを削除 (OWNER のみ、最後の OWNER は削除不可)",
+  middleware: [withGroupAccess((c) => c.req.param("groupId"), "OWNER")] as const,
+  request: { params: GroupAndUserParamSchema },
+  responses: {
+    204: { description: "削除成功" },
+    401: {
+      description: "未認証",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "OWNER でない / 未参加",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "対象メンバーが存在しない",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    422: {
+      description: "最後の OWNER の削除試行",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export const membershipsRouter = new OpenAPIHono<AppEnv>()
+  .openapi(listMembershipsRoute, async (c) => {
+    const { groupId } = c.req.valid("param")
+    const db = c.get("db")
+
+    const rows = await db
+      .select()
+      .from(memberships)
+      .where(and(eq(memberships.groupId, groupId), isNull(memberships.deletedAt)))
+
+    return c.json({ memberships: rows.map(toMembershipDto) }, 200)
+  })
+  .openapi(patchMembershipRoute, async (c) => {
+    const { groupId, userId } = c.req.valid("param")
+    const body = c.req.valid("json")
+    const db = c.get("db")
+    const currentUserId = c.get("userId")
+
+    const [target] = await db
+      .select()
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.groupId, groupId),
+          eq(memberships.userId, userId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+    if (!target) {
+      return c.json({ error: { code: "NOT_FOUND", message: "対象メンバーが見つかりません" } }, 404)
+    }
+
+    // 自分自身を OWNER から降格させると group が orphan 化するリスクがあるため、
+    // 自身の OWNER 剥奪のみ拒否する。他者の昇格・降格は OK。
+    if (target.userId === currentUserId && target.role === "OWNER" && body.role !== "OWNER") {
+      return c.json(
+        {
+          error: {
+            code: "SELF_OWNER_DEMOTE",
+            message: "自分自身の OWNER 権限は剥奪できません",
+          },
+        },
+        422,
+      )
+    }
+
+    const [updated] = await db
+      .update(memberships)
+      .set({ role: body.role, updatedAt: new Date() })
+      .where(
+        and(
+          eq(memberships.groupId, groupId),
+          eq(memberships.userId, userId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .returning()
+    if (!updated) {
+      throw new Error("membership update returned no row")
+    }
+
+    return c.json({ membership: toMembershipDto(updated) }, 200)
+  })
+  .openapi(deleteMembershipRoute, async (c) => {
+    const { groupId, userId } = c.req.valid("param")
+    const db = c.get("db")
+
+    const [target] = await db
+      .select()
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.groupId, groupId),
+          eq(memberships.userId, userId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+      .limit(1)
+    if (!target) {
+      return c.json({ error: { code: "NOT_FOUND", message: "対象メンバーが見つかりません" } }, 404)
+    }
+
+    // 削除対象が OWNER の場合、削除後に少なくとも 1 名 OWNER が残ることを保証する。
+    // 同 tx 内に置かないのは race の影響が「最後の OWNER が並行で抜ける」レアケースに限定され、
+    // 実害は再 invite で復旧可能なため。厳密性が必要なら SERIALIZABLE iso か行ロックで補強する。
+    if (target.role === "OWNER") {
+      const rows = await db
+        .select({ remaining: count() })
+        .from(memberships)
+        .where(
+          and(
+            eq(memberships.groupId, groupId),
+            eq(memberships.role, "OWNER"),
+            ne(memberships.userId, userId),
+            isNull(memberships.deletedAt),
+          ),
+        )
+      // SQL の COUNT は常に 1 行返す (空集合でも { count: 0 })
+      const remaining = rows[0]?.remaining ?? 0
+      if (remaining === 0) {
+        return c.json(
+          {
+            error: {
+              code: "LAST_OWNER",
+              message: "最後の OWNER は削除できません",
+            },
+          },
+          422,
+        )
+      }
+    }
+
+    const now = new Date()
+    await db
+      .update(memberships)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(memberships.groupId, groupId),
+          eq(memberships.userId, userId),
+          isNull(memberships.deletedAt),
+        ),
+      )
+
+    return c.body(null, 204)
+  })

--- a/apps/core/api/src/routes/schemas.ts
+++ b/apps/core/api/src/routes/schemas.ts
@@ -40,6 +40,39 @@ export const membershipDtoSchema = z
   })
   .openapi("Membership")
 
+// 招待発行時の role は EDITOR / VIEWER のみ。OWNER は手動 PATCH で昇格させる。
+export const inviteRoleSchema = z.enum(["EDITOR", "VIEWER"]).openapi("InviteRole")
+
+export const invitationDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    groupId: z.string().uuid(),
+    inviterId: z.string().uuid(),
+    role: roleSchema,
+    token: z.string(),
+    expiresAt: z.string().datetime({ offset: true }),
+    usedAt: z.string().datetime({ offset: true }).nullable(),
+    usedBy: z.string().uuid().nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    deletedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .openapi("Invitation")
+
+export const createInvitationBodyDtoSchema = z
+  .object({
+    role: inviteRoleSchema,
+    // 1〜90 日。default は handler 側で 7 日に置き換える。
+    expiresInDays: z.number().int().min(1).max(90).optional(),
+  })
+  .openapi("CreateInvitationBody")
+
+export const updateMembershipRoleBodyDtoSchema = z
+  .object({
+    role: roleSchema,
+  })
+  .openapi("UpdateMembershipRoleBody")
+
 export const createGroupBodyDtoSchema = z
   .object({
     name: z.string().min(1).max(100),


### PR DESCRIPTION
## 概要 / Why

UC-09「メンバーを招待・権限変更・削除」相当を実装し、グループに他ユーザーを招待・管理する API を提供する。OWNER / EDITOR / VIEWER の 3 ロールを使って操作権限を制御する。

## 変更内容 / What

### 招待 (invitations テーブル)
- `POST /v1/groups/:groupId/invitations` (OWNER のみ) — 招待トークン発行
  - body: \`{ role: \"EDITOR\" | \"VIEWER\", expiresInDays?: 1..90 }\`
  - default 7 日。token は \`crypto.randomUUID()\` (URL-safe)
- `POST /v1/invitations/:token/accept` — current user が membership に加わる
  - membership 作成と invitations.usedAt/usedBy 更新を 1 tx で原子化
  - 期限切れ → 422 \`INVITATION_EXPIRED\`、使用済み → 409 \`INVITATION_USED\`
  - 既 member → 409 \`ALREADY_MEMBER\` (冪等性は取らずエラーで知らせる方針)

### メンバー管理
- `GET /v1/groups/:groupId/memberships` — 全 member に open
- `PATCH /v1/groups/:groupId/memberships/:userId` (OWNER のみ) — role 変更
  - 自身の OWNER 剥奪のみ拒否 (\`SELF_OWNER_DEMOTE\` 422)。他者の昇格・降格は OK
- `DELETE /v1/groups/:groupId/memberships/:userId` (OWNER のみ) — soft delete
  - 削除後に **少なくとも 1 名 OWNER が残る** ことを保証 (\`LAST_OWNER\` 422)

### スキーマ
- \`invitationDtoSchema\` / \`createInvitationBodyDtoSchema\` (role: EDITOR|VIEWER)
- \`updateMembershipRoleBodyDtoSchema\` (role)

### マウント
\`/v1\` 直下に 2 router を full-path で乗せた:
\`\`\`ts
.route(\"/v1\", membershipsRouter) // /v1/groups/{groupId}/memberships
.route(\"/v1\", invitationsRouter) // /v1/groups/{groupId}/invitations + /v1/invitations/{token}/accept
\`\`\`

## スコープ外 / Out of scope

- 招待 URL の発行・メール送付 (frontend で組み立て、サーバは token を返すだけ)
- QR コード化
- 招待 token の不正推測対策強化 (現状は randomUUID。`randomBytes(32).base64url` 等は別 Issue)

## 設計判断

- **token 推測耐性**: v1.0.0 では UUIDv4 で十分 (122-bit ランダム)。家族・知人内で URL を直接共有する想定で、悪意の総当たりは想定外。気になれば PR で議論
- **last-OWNER race**: トランザクション境界外で count するため、並行で OWNER が同時に削除を実行すると最後の 1 名が残らない理論的な隙間あり。実害は再 invite で復旧可能なため許容。厳密性が必要なら SERIALIZABLE iso か行ロックで補強できるとコメントに記載
- **expired/used の status 使い分け**: used → 409 (Conflict / 状態の二重操作)、expired → 422 (validation 系)。issue 本文の選択肢通り

## 検証 / Test plan

- [x] \`bun run --filter @prep-hamster/api typecheck\`
- [x] \`bun run --filter @prep-hamster/api test:e2e\` (79 pass、+15 ケース)
- [x] \`bun x oxfmt --check\` / \`bun x oxlint\`

### 追加 E2E (15 ケース)
- memberships:
  - GET 一覧 (member OK / outsider 403)
  - PATCH 昇格 (OWNER OK / EDITOR 403)
  - PATCH self OWNER 剥奪 → 422 \`SELF_OWNER_DEMOTE\`
  - DELETE last OWNER → 422 \`LAST_OWNER\`
  - DELETE 別 OWNER 存在時 → 204 (再削除は 404)
  - DELETE EDITOR by OWNER → 204
- invitations:
  - POST 発行 (token / role / expires 7d ±)
  - POST EDITOR が発行試行 → 403
  - accept 成功 (membership 作成 + token used)
  - accept 二重 → 409 \`INVITATION_USED\`
  - accept 期限切れ (DB 直書きで 1s 過去) → 422
  - accept 既 member → 409 \`ALREADY_MEMBER\`
  - accept 不在 token → 404

## 関連 Issue / Links

- Closes #68
- 依存: #67 (groups), #69 (group access middleware)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を \`Closes #N\` でリンクしている
- [ ] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * グループへのメンバー招待機能を追加。招待トークンの生成・受け入れが可能に（デフォルト有効期限7日、カスタマイズ可能）
  * メンバーシップ管理機能を追加。ロール変更（昇進・降格）およびメンバー削除が可能に

* **Tests**
  * 招待フローとメンバーシップ管理の包括的なエンドツーエンドテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->