### PR TITLE
test(mobile): add unit tests for env fallbacks and stock list join

### DIFF
--- a/apps/user/client/mobile/package.json
+++ b/apps/user/client/mobile/package.json
@@ -9,7 +9,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "test": "bun test src"
   },
   "dependencies": {
     "@prep-hamster/api-client": "workspace:*",

--- a/apps/user/client/mobile/src/__tests__/api.test.ts
+++ b/apps/user/client/mobile/src/__tests__/api.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { resolveApiBaseUrl } from "../api"
+
+test("resolveApiBaseUrl returns the env override when set", () => {
+  expect(resolveApiBaseUrl({ EXPO_PUBLIC_API_BASE_URL: "http://192.168.1.10:3000" })).toBe(
+    "http://192.168.1.10:3000",
+  )
+})
+
+test("resolveApiBaseUrl falls back to localhost:3000 when env is unset", () => {
+  expect(resolveApiBaseUrl({})).toBe("http://localhost:3000")
+})

--- a/apps/user/client/mobile/src/__tests__/auth.test.ts
+++ b/apps/user/client/mobile/src/__tests__/auth.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { getCurrentUserId } from "../auth"
+
+const ENV_KEY = "EXPO_PUBLIC_STUB_USER_ID"
+let original: string | undefined
+
+beforeEach(() => {
+  original = process.env[ENV_KEY]
+})
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env[ENV_KEY]
+  } else {
+    process.env[ENV_KEY] = original
+  }
+})
+
+test("getCurrentUserId returns the env override when set", () => {
+  process.env[ENV_KEY] = "11111111-1111-1111-1111-111111111111"
+  expect(getCurrentUserId()).toBe("11111111-1111-1111-1111-111111111111")
+})
+
+test("getCurrentUserId falls back to a fixed UUID when env is unset", () => {
+  delete process.env[ENV_KEY]
+  expect(getCurrentUserId()).toBe("00000000-0000-0000-0000-000000000001")
+})

--- a/apps/user/client/mobile/src/__tests__/config.test.ts
+++ b/apps/user/client/mobile/src/__tests__/config.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { getCurrentGroupId } from "../config"
+
+const ENV_KEY = "EXPO_PUBLIC_STUB_GROUP_ID"
+let original: string | undefined
+
+beforeEach(() => {
+  original = process.env[ENV_KEY]
+})
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env[ENV_KEY]
+  } else {
+    process.env[ENV_KEY] = original
+  }
+})
+
+test("getCurrentGroupId returns the env override when set", () => {
+  process.env[ENV_KEY] = "22222222-2222-2222-2222-222222222222"
+  expect(getCurrentGroupId()).toBe("22222222-2222-2222-2222-222222222222")
+})
+
+test("getCurrentGroupId falls back to a fixed UUID when env is unset", () => {
+  delete process.env[ENV_KEY]
+  expect(getCurrentGroupId()).toBe("00000000-0000-0000-0000-000000000010")
+})

--- a/apps/user/client/mobile/src/__tests__/use-stocks.test.ts
+++ b/apps/user/client/mobile/src/__tests__/use-stocks.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { joinStocksWithMasters } from "../use-stocks"
+
+test("joinStocksWithMasters joins by id with item / location names", () => {
+  const stocks = [
+    {
+      id: "s1",
+      itemId: "i1",
+      locationId: "l1",
+      quantity: 3,
+      unit: "個",
+      useByDate: "2026-06-01",
+      bestBeforeDate: null,
+    },
+  ]
+  const items = [{ id: "i1", name: "Tomato" }]
+  const locations = [{ id: "l1", name: "Pantry" }]
+  expect(joinStocksWithMasters(stocks, items, locations)).toEqual([
+    {
+      id: "s1",
+      itemName: "Tomato",
+      locationName: "Pantry",
+      quantity: 3,
+      unit: "個",
+      useByDate: "2026-06-01",
+      bestBeforeDate: null,
+    },
+  ])
+})
+
+test("joinStocksWithMasters falls back to '(unknown ...)' when masters are missing", () => {
+  const stocks = [
+    {
+      id: "s1",
+      itemId: "missing-item",
+      locationId: "missing-loc",
+      quantity: 1,
+      unit: "個",
+      useByDate: null,
+      bestBeforeDate: null,
+    },
+  ]
+  const rows = joinStocksWithMasters(stocks, [], [])
+  expect(rows[0]?.itemName).toBe("(unknown item)")
+  expect(rows[0]?.locationName).toBe("(unknown location)")
+})
+
+test("joinStocksWithMasters preserves the input order of stocks", () => {
+  const stocks = [
+    {
+      id: "a",
+      itemId: "i",
+      locationId: "l",
+      quantity: 1,
+      unit: "個",
+      useByDate: null,
+      bestBeforeDate: null,
+    },
+    {
+      id: "b",
+      itemId: "i",
+      locationId: "l",
+      quantity: 1,
+      unit: "個",
+      useByDate: null,
+      bestBeforeDate: null,
+    },
+    {
+      id: "c",
+      itemId: "i",
+      locationId: "l",
+      quantity: 1,
+      unit: "個",
+      useByDate: null,
+      bestBeforeDate: null,
+    },
+  ]
+  const rows = joinStocksWithMasters(stocks, [{ id: "i", name: "X" }], [{ id: "l", name: "Y" }])
+  expect(rows.map((r) => r.id)).toEqual(["a", "b", "c"])
+})

--- a/apps/user/client/mobile/src/api.ts
+++ b/apps/user/client/mobile/src/api.ts
@@ -9,9 +9,15 @@ import { getCurrentUserId } from "./auth"
 
 const FALLBACK_BASE_URL = "http://localhost:3000"
 
+// env 解決を切り出して unit test 可能にする。getApiClient 自体は createApiClient を
+// 呼び出すため副作用 (network ベース) を含む。
+export function resolveApiBaseUrl(env: Record<string, string | undefined> = process.env): string {
+  return env["EXPO_PUBLIC_API_BASE_URL"] ?? FALLBACK_BASE_URL
+}
+
 export function getApiClient(): ApiClient {
   return createApiClient({
-    baseUrl: process.env.EXPO_PUBLIC_API_BASE_URL ?? FALLBACK_BASE_URL,
+    baseUrl: resolveApiBaseUrl(),
     userId: getCurrentUserId(),
   })
 }

--- a/apps/user/client/mobile/src/use-stocks.ts
+++ b/apps/user/client/mobile/src/use-stocks.ts
@@ -21,6 +21,36 @@ type State =
   | { status: "ok"; rows: StockListItem[] }
   | { status: "error"; message: string }
 
+type StockRow = {
+  id: string
+  itemId: string
+  locationId: string
+  quantity: number
+  unit: string
+  useByDate: string | null
+  bestBeforeDate: string | null
+}
+
+// items / locations を id → name の Map に畳み込み、stocks に画面表示用 join した行を作る。
+// hook 本体から切り出すことで描画なしの unit test で挙動を固定できる。
+export function joinStocksWithMasters(
+  stocks: StockRow[],
+  items: { id: string; name: string }[],
+  locations: { id: string; name: string }[],
+): StockListItem[] {
+  const itemMap = new Map(items.map((i) => [i.id, i.name]))
+  const locMap = new Map(locations.map((l) => [l.id, l.name]))
+  return stocks.map((s) => ({
+    id: s.id,
+    itemName: itemMap.get(s.itemId) ?? "(unknown item)",
+    locationName: locMap.get(s.locationId) ?? "(unknown location)",
+    quantity: s.quantity,
+    unit: s.unit,
+    useByDate: s.useByDate,
+    bestBeforeDate: s.bestBeforeDate,
+  }))
+}
+
 export function useStocks(): { state: State; reload: () => void } {
   const [state, setState] = useState<State>({ status: "loading" })
   const [reloadKey, setReloadKey] = useState(0)
@@ -54,20 +84,7 @@ export function useStocks(): { state: State; reload: () => void } {
         const stocks = (await stocksRes.json()).stocks
         const items = (await itemsRes.json()).items
         const locations = (await locationsRes.json()).locations
-
-        const itemMap = new Map(items.map((i) => [i.id, i.name]))
-        const locMap = new Map(locations.map((l) => [l.id, l.name]))
-
-        const rows: StockListItem[] = stocks.map((s) => ({
-          id: s.id,
-          itemName: itemMap.get(s.itemId) ?? "(unknown item)",
-          locationName: locMap.get(s.locationId) ?? "(unknown location)",
-          quantity: s.quantity,
-          unit: s.unit,
-          useByDate: s.useByDate,
-          bestBeforeDate: s.bestBeforeDate,
-        }))
-        setState({ status: "ok", rows })
+        setState({ status: "ok", rows: joinStocksWithMasters(stocks, items, locations) })
       } catch (err) {
         if (cancelled) return
         const message = err instanceof Error ? err.message : "unknown"

--- a/apps/user/client/mobile/tsconfig.json
+++ b/apps/user/client/mobile/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "module": "ESNext",
+    "types": ["bun"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## 概要 / Why

mobile はこれまで実機 / シミュレータでの手動検証のみで、自動テストが 0 件だった。視覚的な検証 (camera scan / form layout) は引き続き手動だが、**純粋関数として切り出せるロジック** だけでも自動化しておく。

## 変更内容 / What

### 切り出した pure helper
- `resolveApiBaseUrl(env)`: `EXPO_PUBLIC_API_BASE_URL` のフォールバック解決を `getApiClient()` から分離
- `joinStocksWithMasters(stocks, items, locations)`: `useStocks` 内の id → name 結合ロジックを hook 本体から分離

### 追加 unit test (9 件)
- `api.test.ts`: env 上書き / fallback (`http://localhost:3000`)
- `auth.test.ts`: `getCurrentUserId()` の env 上書き / fallback
- `config.test.ts`: `getCurrentGroupId()` の env 上書き / fallback
- `use-stocks.test.ts`: 結合 / 不在 master の `(unknown ...)` フォールバック / 順序保持

### tsconfig / package.json
- `"types": ["bun"]` を mobile/tsconfig.json に追加 (`bun:test` 解決)
- `"test": "bun test src"` script 追加。Turborepo の `test` task に乗るため `bun run test` (CI) で自動実行される

## スコープ外 / Out of scope

- React 描画を伴う hook テスト (`@testing-library/react-native` の導入は別 Issue)
- camera scan / DateTimePicker 等の visual verification (実機 / シミュレータでの手動検証)
- snapshot test

## 検証 / Test plan

- [x] `bun run --filter @prep-hamster/mobile typecheck`
- [x] `bun run --filter @prep-hamster/mobile test` (9 pass)
- [x] `bun run test` (全 12 packages pass)
- [x] `bun x oxfmt --check` / `bun x oxlint`

## 関連 Issue / Links

- v1.0.0 vertical slice (#76 / #77) で見送った mobile 自動化を後追い
- Refs: `MEMORY.md` の `v1.0.0 MVP landed` の「mobile は scaffold + UI コードのみで実機検証は未実施」

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない
