### PR TITLE
feat(mobile): add icons to bottom tabs (Ionicons list / add-circle)

### DIFF
--- a/apps/user/client/mobile/app/(tabs)/_layout.tsx
+++ b/apps/user/client/mobile/app/(tabs)/_layout.tsx
@@ -1,10 +1,23 @@
+import { Ionicons } from "@expo/vector-icons"
 import { Tabs } from "expo-router"
 
 export default function TabsLayout() {
   return (
     <Tabs screenOptions={{ headerShown: true }}>
-      <Tabs.Screen name="index" options={{ title: "在庫" }} />
-      <Tabs.Screen name="add" options={{ title: "追加" }} />
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: "在庫",
+          tabBarIcon: ({ color, size }) => <Ionicons name="list" color={color} size={size} />,
+        }}
+      />
+      <Tabs.Screen
+        name="add"
+        options={{
+          title: "追加",
+          tabBarIcon: ({ color, size }) => <Ionicons name="add-circle" color={color} size={size} />,
+        }}
+      />
     </Tabs>
   )
 }


### PR DESCRIPTION
## 概要 / Why

PR #99 の bundle 動作確認スクショで、bottom tabs に icon が表示されておらず空白 / プレースホルダ状態になっているのが判明したため。Issue #100 で報告。

## 変更内容 / What

`apps/user/client/mobile/app/(tabs)/_layout.tsx` の各 `Tabs.Screen` に `tabBarIcon` を追加。アイコンライブラリは `expo` に同梱の `@expo/vector-icons` から `Ionicons` を使用。

- **在庫タブ**: `Ionicons "list"`
- **追加タブ**: `Ionicons "add-circle"`

focus / unfocus 時の色は Tabs default の挙動に任せ（active = 青 / inactive = グレー）、`color` / `size` props をそのまま渡している。

#96 (design-tokens) の作業で primary icon set を統一する予定なので、本 PR では「空白を埋める」スコープに限定し、tint color / size 調整は次回以降。

## スコープ外 / Out of scope

- icon set の統一・design token 化（#96 で対応）
- screen catalog (`docs/design/screens-as-is/home-add-entry.png`) のアイコン入り再撮影 — `docs/design/screens-as-is.md` の更新は別 PR で扱う（catalog 自体は PR #97 で merge 済み）

## 動作確認

Android emulator (Pixel 5 / Android 14 / `system-images;android-34;google_apis;x86_64`) + Metro dev-client で local install したアプリで以下を視認:

- 在庫タブ: list 風アイコン (3 本線) が active 状態で青色表示
- 追加タブ: +（plus-circle）アイコンが inactive 状態でグレー表示
- 在庫タブが起動時に focus されている状態でアイコン色が active 色に切り替わっている

`bun run --filter @prep-hamster/mobile typecheck` / `bun x oxlint` / `bun x oxfmt --check` いずれも pass。

## 関連 Issue / Links

- Closes #100
- 関連: #96 (design-tokens), #97 (As-Is screen catalog 基盤)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * タブバーにアイコンを追加しました。リストと追加ボタンのタブにそれぞれアイコンが表示されるようになり、ナビゲーションが視覚的にわかりやすくなりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TakashiAihara/prep-hamster/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->