### PR TITLE
test(mobile): add testID to manual barcode TextInput

### DIFF
--- a/apps/user/client/mobile/app/add/manual.tsx
+++ b/apps/user/client/mobile/app/add/manual.tsx
@@ -27,6 +27,7 @@ export default function ManualBarcodeScreen() {
     <View style={styles.container}>
       <Text style={styles.label}>JAN コード (EAN-13 / EAN-8)</Text>
       <TextInput
+        testID="input"
         value={barcode}
         onChangeText={setBarcode}
         keyboardType="number-pad"


### PR DESCRIPTION
## 概要 / Why

PR #97 で Maestro flow `apps/user/client/mobile/maestro/add-manual.yaml` を実装した際に、`tapOn: id: "input"` が WARNED となり TextInput に focus できず、続く `inputText` が input field に届かなかった (詳細: Issue #108)。

結果として PR #97 commit に含まれた catalog png のうち `add-manual-input.png` と `add-manual-after-submit.png` が完全に同一 md5 になっていた (barcode state 空のまま送信ボタン disabled → 画面遷移なし)。

## 変更内容 / What

`apps/user/client/mobile/app/add/manual.tsx` の `TextInput` に `testID="input"` を付与する 1 行追加のみ。flow 側 (`add-manual.yaml`) は既に `tapOn: id: "input"` を期待しているので app 側の対応だけで通る。

```diff
       <TextInput
+        testID="input"
         value={barcode}
```

## 動作確認

Android emulator (Pixel 5 / Android 14 / `system-images;android-34;google_apis;x86_64`) で `maestro test maestro/add-manual.yaml` を実行し、以下を確認:

- `Tap on (Optional) id: input... COMPLETED` (PR #97 時は `WARNED`)
- 出力 3 png の md5 が **すべて別** (前回は input と after-submit が同一)
  - `add-manual-input.png`: `e5129c09...`
  - `add-manual-input-filled.png`: `f63ddabc...`
  - `add-manual-after-submit.png`: `7fa59d03...`

`bun run --filter @prep-hamster/mobile typecheck` / `bun x oxlint` / `bun x oxfmt --check` pass。

## スコープ外 / Out of scope

- `docs/design/screens-as-is/` の png 差し替え (catalog 再生成は別 PR、capture を回し直すだけなので軽い)
- 他 TextInput への testID 一括付与 (現状 input field を Maestro flow から触るのはこの 1 箇所のみ)

## 関連 Issue / Links

- Closes #108
- Refs #97 (As-Is screen catalog、本修正の元 PR)

## チェックリスト

- [x] PR タイトルが Conventional Commits に従っている
- [x] 関連 Issue を `Closes #N` でリンクしている
- [x] CI（Typecheck / Test）が通っている
- [x] スコープ外の変更を含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト識別の改善を実施しました。

---

**注記**: このリリースでは、主にテスト関連の内部改善が含まれており、ユーザーに直接影響する変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TakashiAihara/prep-hamster/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->